### PR TITLE
Rename time_lag parameter as lag

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -62,7 +62,7 @@ jobs:
           python3 -m pytest tests/ -v --junit-xml=test-results.xml
       
       - name: Run Sonar code analysis
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/benchmarks/bench_mutual_information.py
+++ b/benchmarks/bench_mutual_information.py
@@ -17,8 +17,8 @@ d = rng.gamma(1.0, 1.0, size=N)
 e = b + 2.0*c
 """
 
-mi_bench = "estimate_mi(d, [a, b, c], time_lag=[-1, 0, 1, 2], k=3)"
-cmi_bench = "estimate_mi(d, [a, b, c], time_lag=[-1, 0, 1, 2], k=3, cond=e)"
+mi_bench = "estimate_mi(d, [a, b, c], lag=[-1, 0, 1, 2], k=3)"
+cmi_bench = "estimate_mi(d, [a, b, c], lag=[-1, 0, 1, 2], k=3, cond=e)"
 
 for (name, bench) in [ ("MI", mi_bench), ("CMI", cmi_bench) ]:
     for n in [ 100, 400, 1600 ]:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -118,7 +118,7 @@ There may be a clear dependence between $Y(t)$ and $X(t-\Delta)$,
 whereas the apparent link between $Y(t)$ and $X(t)$ may be weaker or nonexistent.
 
 The time lag is specified by passing an integer or a list/array of integers as
-the `time_lag` parameter to `estimate_mi()`.
+the `lag` parameter to `estimate_mi()`.
 The lags are applied to the $X_i$ variables and may be positive or negative
 (in which case information flows from $Y$ to $X$ instead).
 
@@ -148,7 +148,7 @@ y = np.zeros(400)
 y[1:] = x[0:-1]
 y += rng.normal(0, 0.01, size=400)
 
-print(estimate_mi(y, x, time_lag=[1, 0, -1]))
+print(estimate_mi(y, x, lag=[1, 0, -1]))
 ```
 
 The code prints:
@@ -178,7 +178,7 @@ import numpy as np
 data = np.loadtxt("mi_example.csv", delimiter=",", skiprows=1, unpack=True)
 time_lags = np.arange(-3, 6)
 
-mi = estimate_mi(data[0], data[1:4], time_lag=time_lags)
+mi = estimate_mi(data[0], data[1:4], lag=time_lags)
 
 plt.plot(time_lags, mi[0,:], label="$x_1$")
 plt.plot(time_lags, mi[1,:], label="$x_2$")
@@ -211,7 +211,7 @@ Suppose that in our previous example, we know that there is a connection
 between $X_1$ and $X_2$.
 We may know this from theory, or maybe by running
 ```python
-estimate_mi(data[2], data[1], time_lag=2)
+estimate_mi(data[2], data[1], lag=2)
 ```
 recognizing the high value, and then plotting the two variables.
 
@@ -227,7 +227,7 @@ import numpy as np
 data = np.loadtxt("mi_example.csv", delimiter=",", skiprows=1, unpack=True)
 time_lags = np.arange(-3, 6)
 
-mi = estimate_mi(data[0], data[(1, 3),:], time_lag=time_lags,
+mi = estimate_mi(data[0], data[(1, 3),:], lag=time_lags,
                  cond=data[2], cond_lag=2)
 
 plt.plot(time_lags, mi[0,:], label="$x_1$")
@@ -292,7 +292,7 @@ rng = np.random.default_rng(1234)
 x = -0.3 * np.cos(2 * np.pi * t / 24) + rng.normal(0, 0.001, len(t))
 y = np.sqrt(np.maximum(0, -np.cos(2 * np.pi * (t-3) / 24))) + rng.normal(0, 0.001, len(t))
 
-print(estimate_mi(y, x, time_lag=[0, 1, 2, 3]))
+print(estimate_mi(y, x, lag=[0, 1, 2, 3]))
 ```
 The result is:
 ```
@@ -302,7 +302,7 @@ The result is:
 To constrain to daytime observations of $Y$ only, replace the last line with
 ```python
 mask = np.logical_and(t % 24 > 6, t % 24 < 18)
-print(estimate_mi(y, x, time_lag=[0, 1, 2, 3], mask=mask))
+print(estimate_mi(y, x, lag=[0, 1, 2, 3], mask=mask))
 ```
 This produces slightly larger MI values:
 ```

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -8,7 +8,7 @@ import itertools
 import numpy as np
 from ._entropy_estimators import _estimate_single_mi, _estimate_conditional_mi
 
-def estimate_mi(y : np.ndarray, x : np.ndarray, lag = 0, 
+def estimate_mi(y : np.ndarray, x : np.ndarray, lag = 0, *,
                 k : int = 3, cond : np.ndarray = None, cond_lag : int = 0,
                 mask : np.ndarray = None, parallel : str = None):
     """Estimate the mutual information between y and each x variable.
@@ -35,7 +35,7 @@ def estimate_mi(y : np.ndarray, x : np.ndarray, lag = 0,
     The calculation is based on Kraskov et al. (2004): Estimating mutual
     information. Physical Review E 69. doi:10.1103/PhysRevE.69.066138
 
-    Required parameters:
+    Positional or keyword parameters:
     ---
     y : array_like
         A 1D array of observations.
@@ -47,7 +47,7 @@ def estimate_mi(y : np.ndarray, x : np.ndarray, lag = 0,
         The values may be any integers with magnitude
         less than the number of observations.
 
-    Optional parameters:
+    Optional keyword parameters:
     ---
     k : int
         The number of neighbors to consider. Default 3.

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -18,7 +18,7 @@ class TestEstimateMi(unittest.TestCase):
         y = [5, 6, 7, 8]
 
         with self.assertRaises(ValueError) as cm:
-            estimate_mi(y, x, time_lag=4)
+            estimate_mi(y, x, lag=4)
         self.assertEqual(str(cm.exception), TOO_LARGE_LAG_MSG)
 
     def test_lag_too_small(self):
@@ -26,7 +26,7 @@ class TestEstimateMi(unittest.TestCase):
         y = [5, 6, 7, 8]
 
         with self.assertRaises(ValueError) as cm:
-            estimate_mi(y, x, time_lag=-4)
+            estimate_mi(y, x, lag=-4)
         self.assertEqual(str(cm.exception), TOO_LARGE_LAG_MSG)
 
     def test_lag_leaves_no_y_observations(self):
@@ -34,7 +34,7 @@ class TestEstimateMi(unittest.TestCase):
         y = [5, 6, 7, 8]
 
         with self.assertRaises(ValueError) as cm:
-            estimate_mi(y, x, time_lag=[2, -2])
+            estimate_mi(y, x, lag=[2, -2])
         self.assertEqual(str(cm.exception), TOO_LARGE_LAG_MSG)
 
     def test_cond_lag_leaves_no_y_observations(self):
@@ -42,7 +42,7 @@ class TestEstimateMi(unittest.TestCase):
         y = [5, 6, 7, 8]
 
         with self.assertRaises(ValueError) as cm:
-            estimate_mi(y, x, time_lag=1, cond=y, cond_lag=3)
+            estimate_mi(y, x, lag=1, cond=y, cond_lag=3)
         self.assertEqual(str(cm.exception), TOO_LARGE_LAG_MSG)
 
     def test_lag_not_integer(self):
@@ -50,7 +50,7 @@ class TestEstimateMi(unittest.TestCase):
         y = [5, 6, 7, 8]
 
         with self.assertRaises(TypeError):
-            estimate_mi(y, x, time_lag=1.2)
+            estimate_mi(y, x, lag=1.2)
 
     def test_mask_with_wrong_length(self):
         x = [1, 2, 3, 4]
@@ -105,7 +105,7 @@ class TestEstimateMi(unittest.TestCase):
         rng = np.random.default_rng(1)
         xy = rng.uniform(0, 1, 40)
 
-        actual = estimate_mi(xy, xy, time_lag=[0, 1, -1])
+        actual = estimate_mi(xy, xy, lag=[0, 1, -1])
 
         self.assertEqual(actual.shape, (1, 3))
         # As above, entropy of xy is exp(1), and values are independent.
@@ -119,7 +119,7 @@ class TestEstimateMi(unittest.TestCase):
         y = np.zeros(40)
         y[1:] = x[:-1]
 
-        actual = estimate_mi(y, x, time_lag=[0, 1, -1])
+        actual = estimate_mi(y, x, lag=[0, 1, -1])
 
         self.assertEqual(actual.shape, (1, 3))
         self.assertAlmostEqual(actual[0,0], 0, delta=0.1)
@@ -132,7 +132,7 @@ class TestEstimateMi(unittest.TestCase):
         y = np.zeros(40)
         y[:-1] = x[1:]
 
-        actual = estimate_mi(y, x, time_lag=[0, 1, -1])
+        actual = estimate_mi(y, x, lag=[0, 1, -1])
 
         self.assertEqual(actual.shape, (1, 3))
         self.assertAlmostEqual(actual[0,0], 0, delta=0.1)
@@ -171,7 +171,7 @@ class TestEstimateMi(unittest.TestCase):
         parallel_modes = [ None, "always", "disable" ]
         for parallel in parallel_modes:
             with self.subTest(parallel=parallel):
-                actual = estimate_mi(data[0], data[1:4], time_lag=[0, 1, 3])
+                actual = estimate_mi(data[0], data[1:4], lag=[0, 1, 3])
 
                 # y(t) depends on x1(t+1)
                 self.assertAlmostEqual(actual[0,0], 0.0, delta=0.05)
@@ -214,7 +214,7 @@ class TestEstimateMi(unittest.TestCase):
         y = list(range(300, 0, -1))
         mask = [ True, False ] * 150
 
-        self.assertGreater(estimate_mi(y, x, time_lag=1, mask=mask), 4)
+        self.assertGreater(estimate_mi(y, x, lag=1, mask=mask), 4)
 
     def test_mask_and_lag(self):
         # Only even y and odd x elements are preserved
@@ -228,7 +228,7 @@ class TestEstimateMi(unittest.TestCase):
         x[mask] = 0
         y[np.logical_not(mask)] = 0
 
-        actual = estimate_mi(y, x, time_lag=1, mask=mask)
+        actual = estimate_mi(y, x, lag=1, mask=mask)
         self.assertGreater(actual, 4)
 
     def test_conditional_mi_with_several_lags(self):
@@ -243,11 +243,11 @@ class TestEstimateMi(unittest.TestCase):
         x = x[2:802]
 
         # As a sanity check, test the non-conditional MI
-        noncond = estimate_mi(z, y, k=5, time_lag=1)
+        noncond = estimate_mi(z, y, k=5, lag=1)
         self.assertGreater(noncond, 1)
 
         # Then the conditional MI
-        actual = estimate_mi(z, y, time_lag=[0,1], k=5, cond=x, cond_lag=1)
+        actual = estimate_mi(z, y, lag=[0,1], k=5, cond=x, cond_lag=1)
 
         self.assertEqual(actual.shape, (1, 2))
         self.assertAlmostEqual(actual[0,0], 0.0, delta=0.05)
@@ -267,7 +267,7 @@ class TestEstimateMi(unittest.TestCase):
 
         lags = [ 0, -1 ]
 
-        actual = estimate_mi(y, x, time_lag=lags, cond=z, cond_lag=2)
+        actual = estimate_mi(y, x, lag=lags, cond=z, cond_lag=2)
         expected = 0.5 * (math.log(8) + math.log(35) - math.log(9) - math.log(24))
 
         self.assertAlmostEqual(actual[0,0], expected, delta=0.03)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -171,7 +171,7 @@ class TestEstimateMi(unittest.TestCase):
         parallel_modes = [ None, "always", "disable" ]
         for parallel in parallel_modes:
             with self.subTest(parallel=parallel):
-                actual = estimate_mi(data[0], data[1:4], lag=[0, 1, 3])
+                actual = estimate_mi(data[0], data[1:4], lag=[0, 1, 3], parallel=parallel)
 
                 # y(t) depends on x1(t+1)
                 self.assertAlmostEqual(actual[0,0], 0.0, delta=0.05)


### PR DESCRIPTION
(A pull request for testing the CI pipeline.)

- Rename `time_lag` to `lag`, it's simpler.
- Extend the comment on how the lag is applied.
- Disallow passing `k`, `cond` and friends positionally; it's best to explicitly state the keyword.
- Simplify the parallel estimation code a bit; this makes both me and Sonar happier.