### PR TITLE
Swap the row/column order to match NumPy/Pandas

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           pip install -e .
           pip install scipy
+          pip install pandas
           pip install pytest
           pip install pytest-cov
       

--- a/benchmarks/bench_mutual_information.py
+++ b/benchmarks/bench_mutual_information.py
@@ -15,10 +15,12 @@ b = np.cos(t) + rng.normal(0, 1, size=N)
 c = rng.normal(2, 5, size=N)
 d = rng.gamma(1.0, 1.0, size=N)
 e = b + 2.0*c
+
+data = np.asarray([a, b, c])
 """
 
-mi_bench = "estimate_mi(d, [a, b, c], lag=[-1, 0, 1, 2], k=3)"
-cmi_bench = "estimate_mi(d, [a, b, c], lag=[-1, 0, 1, 2], k=3, cond=e)"
+mi_bench = "estimate_mi(d, data, lag=[-1, 0, 1, 2], k=3)"
+cmi_bench = "estimate_mi(d, data, lag=[-1, 0, 1, 2], k=3, cond=e)"
 
 for (name, bench) in [ ("MI", mi_bench), ("CMI", cmi_bench) ]:
     for n in [ 100, 400, 1600 ]:


### PR DESCRIPTION
**Breaking change.** A bit clumsier when working with Plain Python data, but I expect Pandas data frames and NumPy arrays to be the primary input to `estimate_mi()`.