### PR TITLE
Fix a crash when lag is a 0-dimensional ndarray

### DIFF
--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -73,9 +73,7 @@ def estimate_mi(y : np.ndarray, x : np.ndarray, lag = 0, *,
     """
 
     # The code below assumes that lag is an array
-    if (isinstance(lag, int)):
-        lag = [lag]
-    lag = np.asarray(lag)
+    lag = np.atleast_1d(lag)
 
     # If x or y is a Python list, convert it to an ndarray
     # Keep the original x parameter around for the Pandas data frame check

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -200,6 +200,19 @@ class TestEstimateMi(unittest.TestCase):
         self.assertAlmostEqual(actual[0,0], 0, delta=0.1)
         self.assertAlmostEqual(actual[1,0], math.exp(1), delta=0.02)
         self.assertAlmostEqual(actual[2,0], 0, delta=0.1)
+        self.assertAlmostEqual(actual[2,0], 0, delta=0.1)
+
+    def test_one_variable_with_single_lag_as_ndarray(self):
+        # There was a bug where ndarray(1) wouldn't be accepted
+        rng = np.random.default_rng(1)
+        x = rng.uniform(0, 1, 40)
+        y = np.zeros(40)
+        y[1:] = x[:-1]
+
+        actual = estimate_mi(y, x, lag=np.asarray(1))
+
+        self.assertEqual(actual.shape, (1, 1))
+        self.assertAlmostEqual(actual[0,0], math.exp(1), delta=0.02)
 
     def test_one_variable_with_lead(self):
         rng = np.random.default_rng(1)


### PR DESCRIPTION
Ensure that the lag is interpreted as a 1-dimensional array. Previously, it could be 1- or 0-dimensional. The 0-dimensional case would only occur if a `ndarray` containing a single value would be passed, for example in
```python
lags = np.arange(0, 10, step=3)
for i in range(len(lags)):
    estimate_mi(y, x_vars, lags[i])
```