### PR TITLE
Make the cond_lag parameter absolute

### DIFF
--- a/docs/potential-issues.md
+++ b/docs/potential-issues.md
@@ -113,6 +113,43 @@ the estimation.
 
 
 
+## Autocorrelation
+The estimation method requires that the observations are
+independent and identically distributed.
+If the samples have significant autocorrelation, the first assumption does not hold.
+In this case, the algorithm may return too high MI values.
+
+In this example, each point is present twice:
+the second occurrence has some added random noise.
+This simulates the autocorrelation between the two samples.
+```python
+from ennemi import estimate_mi
+import numpy as np
+
+rng = np.random.default_rng(1234)
+rho = 0.8
+cov = np.array([[1, rho], [rho, 1]])
+
+data = rng.multivariate_normal([0, 0], cov, size=800)
+x = np.concatenate((data[:,0], data[:,0] + rng.normal(0, 0.05, size=800)))
+y = np.concatenate((data[:,1], data[:,1] + rng.normal(0, 0.05, size=800)))
+
+print(estimate_mi(y, x))
+```
+
+Running the code outputs
+```
+[[0.64964189]]
+```
+a significantly higher value than the $\approx 0.51$ expected of
+non-autocorrelated samples.
+
+The way of fixing this depends on your data.
+Does it make sense to look at deseasonalized or differenced data?
+Can you reduce the sampling frequency so that the autocorrelation is smaller?
+
+
+
 ## Improving performance
 Even though `ennemi` uses good algorithms (in terms of asymptotic performance),
 it is not designed for high-performance computing.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -246,7 +246,7 @@ data = pd.read_csv("mi_example.csv")
 time_lags = np.arange(-3, 6)
 
 mi = estimate_mi(data["y"], data[["x1", "x3"]], lag=time_lags,
-                 cond=data["x2"], cond_lag=2)
+                 cond=data["x2"], cond_lag=time_lags+2)
 print(mi)
 
 plt.plot(time_lags, mi["x1"], label="$x_1$")

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -84,7 +84,7 @@ class TestEstimateMi(unittest.TestCase):
         y = [5, 6, 7, 8]
 
         with self.assertRaises(ValueError) as cm:
-            estimate_mi(y, x, lag=1, cond=y, cond_lag=3)
+            estimate_mi(y, x, lag=1, cond=y, cond_lag=4)
         self.assertEqual(str(cm.exception), TOO_LARGE_LAG_MSG)
 
     def test_lag_not_integer(self):
@@ -381,7 +381,7 @@ class TestEstimateMi(unittest.TestCase):
         self.assertGreater(noncond, 1)
 
         # Then the conditional MI
-        actual = estimate_mi(z, y, lag=[0,1], k=5, cond=x, cond_lag=1)
+        actual = estimate_mi(z, y, lag=[0,1], k=5, cond=x, cond_lag=[1, 2])
 
         self.assertEqual(actual.shape, (2, 1))
         self.assertAlmostEqual(actual[0,0], 0.0, delta=0.05)
@@ -405,7 +405,7 @@ class TestEstimateMi(unittest.TestCase):
 
         lags = [ 0, -1 ]
 
-        actual = estimate_mi(y, x, lag=lags, cond=z, cond_lag=2, mask=mask)
+        actual = estimate_mi(y, x, lag=lags, cond=z, cond_lag=[2, 1], mask=mask)
         expected = 0.5 * (math.log(8) + math.log(35) - math.log(9) - math.log(24))
 
         self.assertAlmostEqual(actual[0,0], expected, delta=0.01)
@@ -417,7 +417,7 @@ class TestEstimateMi(unittest.TestCase):
         data = pd.read_csv(data_path)
 
         actual = estimate_mi(data["y"], data["x1"], lag=-1,
-                             cond=data["x2"], cond_lag=1)
+                             cond=data["x2"], cond_lag=0)
 
         self.assertIsInstance(actual, pd.DataFrame)
         self.assertEqual(actual.shape, (1, 1))


### PR DESCRIPTION
Previously, `cond_lag` was a scalar relative to `lag`. This makes it impossible to have an unlagged condition combined with several lags at once. Now `cond_lag` is an array broadcastable to the size of `lag`. The previous behavior of relative lag is achievable by setting `cond_lag=lag`. This also enables running the analysis with several conditional lags.

A possible future enhancement: a separate lag for each condition variable. This should be a non-breaking change, by extending the `cond_lag` to also allow 2D arrays.

Also took a tiny documentation improvement along for the ride.