### PR TITLE
Fix Windows continuous integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,16 +19,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ 3.6, 3.7, 3.8 ]
         # Save a bit of resources by running only some combinations:
-        # Ubuntu 3.6, Ubuntu 3.8 and macOS 3.7
-        # TODO: Windows tests crash without explanation
+        # Windows 3.6, macOS 3.7 and Ubuntu 3.8
         exclude:
+          - os: windows-latest
+            python-version: 3.7
+          - os: windows-latest
+            python-version: 3.8
           - os: macos-latest
             python-version: 3.6
           - os: macos-latest
             python-version: 3.8
+          - os: ubuntu-latest
+            python-version: 3.6
           - os: ubuntu-latest
             python-version: 3.7
 
@@ -47,20 +52,20 @@ jobs:
           pip install scipy
           pip install pandas
           pip install pytest
-          pip install pytest-cov
       
       - name: Run unit tests (with coverage)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
         # We have to rename the path in coverage.xml since Sonar is run in Docker
         # and has a different view of the file system
         run: |
-          python3 -m pytest tests/ --cov=ennemi --cov-report=xml --junit-xml=test-results.xml
+          pip install pytest-cov
+          python -m pytest tests/ --cov=ennemi --cov-report=xml --junit-xml=test-results.xml
           sed 's/\/home\/runner\/work\/ennemi\/ennemi/\/github\/workspace/g' coverage.xml > coverage-mod.xml
       
       - name: Run unit tests (no coverage)
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.8'
         run: |
-          python3 -m pytest tests/ -v --junit-xml=test-results.xml
+          python -m pytest tests/ -v --junit-xml=test-results.xml
       
       - name: Run Sonar code analysis
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'


### PR DESCRIPTION
Windows CI was disabled because the test leg crashed before any output was printed. Turns out that the reason was calling `python3` instead of `python`. Added Windows to the test matrix. Also moved the `pytest-cov` installation to happen only when running tests with coverage.