### PR TITLE
Start the 1.0.0alpha2 development cycle

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,12 +46,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies and pytest
+      - name: Install test dependencies
         run: |
-          pip install -e .
-          pip install scipy
-          pip install pandas
-          pip install pytest
+          pip install -e .[dev]
       
       - name: Run unit tests (with coverage)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
@@ -69,7 +66,6 @@ jobs:
 
       - name: Run type checker
         run: |
-          pip install mypy
           python -m mypy --disallow-untyped-defs ennemi/ tests/
       
       - name: Run Sonar code analysis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing to `ennemi`
+
+Thank you for your interest in contributing to `ennemi` development, awesome!
+Please read through the following quick points on the workflow.
+
+
+## Code of Conduct
+Everybody is welcome to contribute to this package
+regardless of their personal or academic background.
+Criticism is encouraged as long as it is constructive and respectful.
+Everybody makes mistakes; I think safely erring is a great way to learn.
+
+This project is maintained by **Petri Laarne**, `firstname.lastname @ helsinki.fi`.
+Feel free to contact me on anything related to using or contributing to this project.
+
+As the project maintainer, I pledge to follow
+[Contributor Covenant 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/)
+and expect other contributors to do the same.
+
+> Examples of behavior that contributes to a positive environment for our community include:
+> 
+> - Demonstrating empathy and kindness toward other people
+> - Being respectful of differing opinions, viewpoints, and experiences
+> - Giving and gracefully accepting constructive feedback
+> - Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+> - Focusing on what is best not just for us as individuals, but for the overall community
+
+As of this writing, the citation for `ennemi` includes Petri Laarne as the author.
+If you contribute to the package, the citation will be changed to
+"Petri Laarne and contributors" for future releases.
+This policy may be updated.
+
+
+## Submitting issues
+All feedback is much appreciated, no matter how big or small.
+Especially in the current alpha/beta phase it is easy to make the package more ergonomic to use.
+Comments on documentation and small pain points ("papercut issues") are really useful there.
+
+To make problems easier to investigate:
+
+- Clearly tell what you are trying to do, what you expect `ennemi` to do and what `ennemi` actually does.
+- If you can attach example code, please do so.
+  Try to make the example minimal and self-contained: remove all lines that are not
+  relevant for the problem, and make any datasets as small as possible
+  (or replace them with constants or random numbers).
+
+
+## Submitting Pull Requests
+Code changes are welcomed as well.
+Before submitting larger changes, please comment on or create an issue
+for discussion on the direction to take.
+You don't need to create an issue for a simple bug fix,
+but it is okay as well.
+Do mention that you are interested in submitting a fix,
+and feel free to ask for help.
+
+Pull requests will go through a code review.
+You may need to address review comments before the change is merged.
+These comments are open for discussion and disagreement.
+The goal is to make the package as good as possible.
+At the same time, "perfect is the enemy of good"; excessive bikeshedding
+and polishing is discouraged.
+
+There are a few technical details you should be aware of.
+
+### Code and commit style
+At the moment, the code is not linted.
+Try to keep the lines shorter than 100 characters,
+preferably less than 80.
+Try to preserve the existing style of files.
+General Python style should be followed.
+
+For Markdown files, the same line length should be followed.
+Prefer starting each sentence on its own line.
+This makes Git diffs easier to read.
+
+Commit messages must not exceed 50 characters, must start with a capital letter
+and must be in present imperative mood.
+For example:
+
+- GOOD: "Update release script to point to live PyPI"
+- BAD: "updated release script to point to live PyPI" (past tense, small letter)
+- BAD: "Release script now points to live PyPI" (not imperative mood)
+
+Commit descriptions are not currently used, but are certainly allowed
+to give more information.
+For more information on good Git commit messages, see the excellent article
+[How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/).
+
+
+### Unit tests
+The package has an extensive unit test suite guarding against regressions.
+Test-driven development is strongly encouraged.
+This means that the process of fixing a bug or creating a new feature is:
+
+1. Write a unit test for the bug / a piece of feature.
+2. Run the test and see that it fails.
+3. Fix the bug / implement the piece of feature.
+4. Run the test and see that it passes.
+5. Repeat until done.
+
+Each pull request is tested by a Continuous Integration bot.
+The automated test run also includes static analysis of code quality.
+Unit test coverage is measured by the script,
+and too low coverage fails the build.
+
+The goal is that the tests fully document the package.
+When reviewing a Pull Request, the code changes should be obvious from the new/modified tests.
+If the tests haven't changed, the assumption is that the behavior hasn't changed either.
+
+
+### Type checking
+The package uses [PEP 484](https://www.python.org/dev/peps/pep-0484/)
+type hints in all code, checked by `mypy`.
+This also includes the test code for completeness.
+Failing type check fails the automated build.
+
+You should run the type check manually before pushing changes,
+unless you really trust your type annotations.
+See the README file for details.
+
+
+
+## The Zen of `ennemi`
+- Practicality is more important than theoretical completeness.
+- The 95% use case is more important than the special cases.
+- Although special uses should be achievable too.
+- Performance is important.
+- But not as important as correctness, usability and portability.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ _Easy-to-use Nearest Neighbor Estimation of Mutual Information_
 
 [![Continuous Integration](https://github.com/polsys/ennemi/workflows/Continuous%20Integration/badge.svg)](https://github.com/polsys/ennemi/actions)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=polsys_ennemi&metric=coverage)](https://sonarcloud.io/dashboard?id=polsys_ennemi)
+[![DOI](https://zenodo.org/badge/247088713.svg)](https://zenodo.org/badge/latestdoi/247088713)
 
 This Python 3 package provides simple methods for estimating mutual information of continuous variables.
 With one method call, you can estimate several variable pairs and time lags at once.
@@ -16,7 +17,10 @@ _Partial Mutual Information for Coupling Analysis of Multivariate Time Series_,
 Physical Review Letters **99**:20 (2007),
 [doi:10.1103/PhysRevLett.99.204101](https://dx.doi.org/10.1103/PhysRevLett.99.204101).
 
-**NOTE:** This package is **alpha** quality. Likelihood of breaking changes to the API is high!
+**NOTE:** This package is **alpha** quality.
+Even though the algorithm is stable, there may still be breaking changes to the API.
+You can see the roadmap of planned additions on the
+[Milestones page](https://github.com/polsys/ennemi/milestones).
 
 
 ## Getting started
@@ -52,6 +56,8 @@ To run the check yourself, execute
 python -m mypy --disallow-untyped-defs ennemi/ tests/
 ```
 
+Please see also the [contribution guidelines](CONTRIBUTING.md).
+
 
 ## Citing
 
@@ -61,8 +67,16 @@ the original copyright notice is preserved.
 This software is provided "as is", functioning to the extent of passing
 the unit tests in the `tests` directory.
 
-Once the project has matured a bit more, a DOI will be requested via Zenodo.
+This package is archived on Zenodo.
+The DOI [10.5281/zenodo.3834018](https://doi.org/10.5281/zenodo.3834018)
+always resolves to the latest version of `ennemi`.
+For reproducibility, you should cite the exact version of the package you have used.
+To do so, use the DOI given on the [Releases](https://github.com/polsys/ennemi/releases) page or on Zenodo.
+
+In the future, a journal article may become the canonical reference for this package.
+You should still also cite the package version you have used.
 
 This package is maintained by Petri Laarne at
 [Institute for Atmospheric and Earth System Research (INAR)](https://www.helsinki.fi/en/inar-institute-for-atmospheric-and-earth-system-research),
 University of Helsinki.
+Please feel free to contact me about any questions or suggestions related to this project.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ For documentation, please see https://polsys.github.io/ennemi.
 ## Building
 
 The tests depend on SciPy and pandas, so you need those installed in addition to NumPy.
+Additionally, `pytest` and `mypy` are required for building the project.
+All of these are installed by the "extras" syntax of `pip`.
 
 To install the package in development mode, clone this repository and execute
 ```sh
-pip install scipy pandas mypy
-pip install -e .
+pip install -e .[dev]
 ```
 in the repository root folder.
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(description_file, encoding="utf-8") as f:
 
 setup(
     name = "ennemi",
-    version = "1.0.0alpha1",
+    version = "1.0.0alpha2",
     description = "Easy-to-use Nearest Neighbor Estimation of Mutual Information",
     long_description = long_description,
     long_description_content_type = "text/markdown",
@@ -36,7 +36,8 @@ setup(
     project_urls = {
         "Documentation": "https://polsys.github.io/ennemi/",
         "Source": "https://github.com/polsys/ennemi/",
-        "Issues": "https://github.com/polsys/ennemi/issues"
+        "Issues": "https://github.com/polsys/ennemi/issues",
+        "Zenodo": "https://doi.org/10.5281/zenodo.3834018"
     },
 
     packages = [ "ennemi" ],

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,8 @@ setup(
 
     packages = [ "ennemi" ],
     python_requires = "~=3.6",
-    install_requires = [ "numpy~=1.13" ]
+    install_requires = [ "numpy~=1.13" ],
+    extras_require = {
+        "dev": ["scipy~=1.4", "pandas~=1.0", "pytest~=5.4", "mypy~=0.770"]
+    }
 )


### PR DESCRIPTION
Small documentation and development ergonomics things bundled together.

- Bump the version number
- Add `CONTRIBUTING` file with contributing instructions
- Collect development dependencies in one place with `extras_require`

Fixes #27. Fixes #14.
