### PR TITLE
Implement pairwise MI estimation

### DIFF
--- a/benchmarks/bench_pairwise_mi.py
+++ b/benchmarks/bench_pairwise_mi.py
@@ -1,0 +1,29 @@
+"""Benchmarks for pairwise MI estimation, with and without conditioning."""
+
+import numpy as np
+import timeit
+
+setup = """
+from ennemi import pairwise_mi
+import numpy as np
+
+rng = np.random.default_rng(0)
+t = np.arange(N)
+
+a = np.sin(t)
+b = np.cos(t) + rng.normal(0, 1, size=N)
+c = rng.normal(2, 5, size=N)
+d = rng.gamma(1.0, 1.0, size=N)
+e = b + 2.0*c
+
+data = np.asarray([a, b, c, d]).T
+"""
+
+mi_bench = "pairwise_mi(data, k=3)"
+cmi_bench = "pairwise_mi(data, k=3, cond=e)"
+
+for (name, bench) in [ ("MI", mi_bench),
+                       ("CMI", cmi_bench) ]:
+    for n in [ 100, 400, 1600 ]:
+        res = timeit.repeat(bench, setup, repeat=5, number=1, globals={"N": n})
+        print(f"{name:<3}, N={n:<4}: min={np.min(res):<6.3} s, mean={np.mean(res):<6.3} s")

--- a/ennemi/__init__.py
+++ b/ennemi/__init__.py
@@ -1,5 +1,5 @@
 """Mutual Information (MI) estimation using the k-nearest neighbor method."""
 
-from ._driver import estimate_mi, normalize_mi
+from ._driver import estimate_mi, normalize_mi, pairwise_mi
 
-__all__ = [ "estimate_mi", "normalize_mi" ]
+__all__ = [ "estimate_mi", "normalize_mi", "pairwise_mi" ]

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -85,8 +85,8 @@ def estimate_mi(y: ArrayLike, x: ArrayLike,
     y : array_like
         A 1D array of observations.
     x : array_like
-        A 1D or 2D array where the rows are one or more variables and the
-        columns are observations. The number of columns must be the same as in y.
+        A 1D or 2D array where the columns are one or more variables and the
+        rows are observations. The number of rows must be the same as in y.
     lag : int or array_like
         A time lag or 1D array of time lags to apply to x. Default 0.
         The values may be any integers with magnitude
@@ -96,10 +96,11 @@ def estimate_mi(y: ArrayLike, x: ArrayLike,
     ---
     k : int
         The number of neighbors to consider. Default 3.
-        Must be smaller than the number of observations left after cropping.
-    cond : array_like
-        A 1D array of observations used for conditioning.
+        Must be smaller than the number of observations left after masking and cropping.
+    cond : array_like or None
+        Optional 1D or 2D array of observations used for conditioning.
         Must have as many observations as y.
+        All variables in a 2D array are used together.
     cond_lag : int
         Lag applied to the cond array.
         Must be broadcastable to the size of `lag`. Default 0.
@@ -111,9 +112,8 @@ def estimate_mi(y: ArrayLike, x: ArrayLike,
         array must match the length `y`.
     parallel : str or None
         Whether to run the estimation in multiple processes. If None (the default),
-        a heuristic will be used for the decision. If "always", each
-        variable / time lag combination will be run in a separate subprocess,
-        with as many concurrent processes as there are processors.
+        a heuristic will be used for the decision. If "always", the estimation
+        will be run on as many concurrent processes as there are processors.
         If "disable", the combinations are estimated sequentially in the current process.
     """
 
@@ -185,7 +185,7 @@ def _estimate_mi(y: np.ndarray, x: np.ndarray, lag: np.ndarray, k: int,
     return result
 
 
-def _check_parameters(x: np.ndarray, y: np.ndarray, k: int,
+def _check_parameters(x: np.ndarray, y: Optional[np.ndarray], k: int,
         cond: Optional[np.ndarray], mask: Optional[np.ndarray]) -> None:
     if k <= 0:
         raise ValueError("k must be greater than zero")
@@ -193,27 +193,116 @@ def _check_parameters(x: np.ndarray, y: np.ndarray, k: int,
     # Validate the array shapes and lengths
     if len(x.shape) > 2:
         raise ValueError("x must be one- or two-dimensional")
-    if len(y.shape) > 1:
-        raise ValueError("y must be one-dimensional")
+    if y is not None:
+        if len(y.shape) > 1:
+            raise ValueError("y must be one-dimensional")
+        if (x.shape[0] != y.shape[0]):
+            raise ValueError("x and y must have same length")
 
     # Validate the mask
-    obs_count = y.shape[0]
+    obs_count = x.shape[0]
     if mask is not None:
         if len(mask.shape) > 1:
             raise ValueError("mask must be one-dimensional")
-        if len(mask) != len(y):
+        if len(mask) != obs_count:
             raise ValueError("mask length does not match y length")
         if mask.dtype != np.bool:
             raise TypeError("mask must contain only booleans")
 
         obs_count = np.sum(mask)
 
-    if (x.shape[0] != y.shape[0]):
-        raise ValueError("x and y must have same length")
     if (cond is not None) and (x.shape[0] != len(cond)):
         raise ValueError("x and cond must have same length")
     if (obs_count <= k):
         raise ValueError("k must be smaller than number of observations")
+
+
+def pairwise_mi(data: ArrayLike, *, k: int = 3, cond: Optional[np.ndarray] = None,
+    mask: Optional[np.ndarray] = None, parallel: Optional[str] = None,
+    normalize: bool = False) -> np.ndarray:
+    """Estimate the pairwise MI between each variable.
+
+    Returns a matrix where the (i,j)'th element is the mutual information
+    between the i'th and j'th columns in the data. The values are in nats or
+    in the normalized scale depending on the `normalize` parameter. The diagonal
+    contains NaNs (for better visualization, as the auto-MI should be infinite).
+
+    Positional or keyword parameters:
+    ---
+    data : array_like
+        A 2D array where the columns are variables and rows are observations.
+
+    Optional keyword parameters:
+    ---
+    k : int
+        The number of neighbors to consider. Default 3.
+        Must be smaller than the number of observations left after masking.
+    cond : array_like or None
+        Optional 1D or 2D array of observations used for conditioning.
+        Must have as many observations as the data.
+        All variables in a 2D array are used together.
+    mask : array_like or None
+        If specified, an array of booleans that gives the data elements to use for
+        estimation. Use this to exclude some observations from consideration
+        while preserving the time series structure of the data. The length of
+        this array must match the length of `data`.
+    normalize: bool
+        If True, the MI values will be normalized to the correlation scale.
+    parallel : str or None
+        Whether to run the estimation in multiple processes. If None (the default),
+        a heuristic will be used for the decision. If "always", the estimation
+        will be run on as many concurrent processes as there are processors.
+        If "disable", the combinations are estimated sequentially in the current process.
+    """
+    data_arr = np.asarray(data)
+    if cond is not None: cond_arr = np.asarray(cond)
+    else: cond_arr = None
+    if mask is not None: mask_arr = np.asarray(mask)
+    else: mask_arr = None
+
+    # If there is just one variable, return the trivial result
+    if data_arr.ndim == 1 or data_arr.shape[1] == 1:
+        return np.full((1,1), np.nan)
+    
+    result = _pairwise_mi(data_arr, k, cond_arr, mask_arr, parallel)
+
+    # Normalize if asked for
+    if normalize:
+        result = normalize_mi(result)
+
+    # If data was a pandas DataFrame, return a DataFrame with matching names
+    if "pandas" in sys.modules:
+        import pandas
+        if isinstance(data, pandas.DataFrame):
+            return pandas.DataFrame(result, index=data.columns, columns=data.columns)
+    return result
+
+
+def _pairwise_mi(data: np.ndarray, k: int, cond: Optional[np.ndarray],
+    mask: Optional[np.ndarray], parallel: Optional[str]) -> np.ndarray:
+    """Strongly typed pairwise MI. The data array is at least 2D."""
+
+    _check_parameters(data, None, k, cond, mask)
+    nvar = data.shape[1]
+
+    # Create a list of variable pairs
+    # By symmetry, it suffices to consider a triangular matrix
+    indices = []
+    for i in range(nvar):
+        for j in range(i+1, nvar):
+            indices.append((i, j))
+
+    # Run the MI estimation for each pair
+    # TODO: Parallelize
+    result = np.full((nvar, nvar), np.nan)
+    for (i,j) in indices:
+        params = (data[:,i], data[:,j], 0, 0, 0, k, mask, cond, 0)
+        mi = _lagged_mi(params)
+
+        result[i,j] = mi
+        result[j,i] = mi
+
+    return result
 
 
 def _should_be_parallel(parallel: Optional[str], indices: list, y: np.ndarray) -> bool:

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -50,9 +50,9 @@ def _normalize(mi: np.float) -> np.float:
 def estimate_mi(y: ArrayLike, x: ArrayLike,
                 lag: Union[Sequence[int], np.ndarray, int] = 0,
                 *, k: int = 3,
-                cond: Optional[np.ndarray] = None,
+                cond: Optional[ArrayLike] = None,
                 cond_lag: Union[Sequence[int], np.ndarray, int] = 0,
-                mask: Optional[np.ndarray] = None,
+                mask: Optional[ArrayLike] = None,
                 normalize: bool = False,
                 parallel: Optional[str] = None) -> np.ndarray:
     """Estimate the mutual information between y and each x variable.
@@ -225,8 +225,8 @@ def _check_parameters(x: np.ndarray, y: Optional[np.ndarray], k: int,
         raise ValueError("k must be smaller than number of observations")
 
 
-def pairwise_mi(data: ArrayLike, *, k: int = 3, cond: Optional[np.ndarray] = None,
-    mask: Optional[np.ndarray] = None, parallel: Optional[str] = None,
+def pairwise_mi(data: ArrayLike, *, k: int = 3, cond: Optional[ArrayLike] = None,
+    mask: Optional[ArrayLike] = None, parallel: Optional[str] = None,
     normalize: bool = False) -> np.ndarray:
     """Estimate the pairwise MI between each variable.
 

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -53,6 +53,7 @@ def estimate_mi(y: ArrayLike, x: ArrayLike,
                 cond: Optional[np.ndarray] = None,
                 cond_lag: Union[Sequence[int], np.ndarray, int] = 0,
                 mask: Optional[np.ndarray] = None,
+                normalize: bool = False,
                 parallel: Optional[str] = None) -> np.ndarray:
     """Estimate the mutual information between y and each x variable.
  
@@ -110,6 +111,9 @@ def estimate_mi(y: ArrayLike, x: ArrayLike,
         while preserving the time series structure of the data. Elements of
         `x` and `cond` are masked with the lags applied. The length of this
         array must match the length `y`.
+    normalize : bool
+        If True, the results will be normalized to correlation coefficient scale.
+        Same as calling `normalize_mi` on the results.
     parallel : str or None
         Whether to run the estimation in multiple processes. If None (the default),
         a heuristic will be used for the decision. If "always", the estimation
@@ -132,6 +136,10 @@ def estimate_mi(y: ArrayLike, x: ArrayLike,
 
     # Check the parameters and run the estimation
     result = _estimate_mi(y_arr, x_arr, lag_arr, k, cond_arr, cond_lag_arr, mask_arr, parallel)
+
+    # Normalize if requested
+    if normalize:
+        result = normalize_mi(result)
 
     # If the input was a pandas data frame, set the column names
     if "pandas" in sys.modules:
@@ -247,7 +255,7 @@ def pairwise_mi(data: ArrayLike, *, k: int = 3, cond: Optional[np.ndarray] = Non
         while preserving the time series structure of the data. The length of
         this array must match the length of `data`.
     normalize: bool
-        If True, the MI values will be normalized to the correlation scale.
+        If True, the MI values will be normalized to correlation coefficient scale.
     parallel : str or None
         Whether to run the estimation in multiple processes. If None (the default),
         a heuristic will be used for the decision. If "always", the estimation

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -473,6 +473,15 @@ class TestEstimateMi(unittest.TestCase):
                     estimate_mi(y, x, cond=cond)
                 self.assertEqual(str(cm.exception), NANS_LEFT_MSG)
 
+    def test_normalization(self) -> None:
+        rng = np.random.default_rng(17)
+        cov = np.asarray([[1, 0.6], [0.6, 1]])
+        data = rng.multivariate_normal([0, 0], cov, 1000)
+
+        result = estimate_mi(data[:,0], data[:,1], normalize=True)
+
+        self.assertAlmostEqual(result, 0.6, delta=0.02)
+
 
 class TestNormalizeMi(unittest.TestCase):
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -473,6 +473,17 @@ class TestEstimateMi(unittest.TestCase):
                     estimate_mi(y, x, cond=cond)
                 self.assertEqual(str(cm.exception), NANS_LEFT_MSG)
 
+    def test_cond_and_mask_as_list(self) -> None:
+        x = [1, 2, 3, 4, 5, math.nan]
+        y = [2, 4, 6, 8, 10, 12]
+        cond = [1, 1, 2, 3, 5, 8]
+        mask = [True, True, True, True, True, False]
+
+        # Not checking for the (bogus) result, just that this
+        # type-checks and does not crash
+        estimate_mi(y, x, cond=cond, mask=mask)
+
+
     def test_normalization(self) -> None:
         rng = np.random.default_rng(17)
         cov = np.asarray([[1, 0.6], [0.6, 1]])


### PR DESCRIPTION
Closes #15. Implemented the `pairwise_mi` method for creating MI matrices. Additionally,

- fixed a couple outdated docstrings,
- clarified some type annotations (although they did not affect mypy results),
- added a `normalize` parameter to `estimate_mi` for consistency.

Did not write documentation for these methods yet, will do that together with other documentation improvements.