### PR TITLE
Start 1.0.0beta1 development cycle

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run type checker
         run: |
-          python -m mypy --disallow-untyped-defs ennemi/ tests/unit tests/integration
+          python -m mypy ennemi/ tests/unit tests/integration
       
       - name: Run Sonar code analysis
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ and expect other contributors to do the same.
 > - Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
 > - Focusing on what is best not just for us as individuals, but for the overall community
 
-As of this writing, the citation for `ennemi` includes Petri Laarne as the author.
-If you contribute to the package, the citation will be changed to
-"Petri Laarne and contributors" for future releases.
+The citation for `ennemi` is "Petri Laarne and contributors" starting from 1.0.0beta1.
+Contributors to a release will be acknowledged in the release notes,
+unless they do not want to be mentioned.
 This policy may be updated.
 
 

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -12,11 +12,11 @@ The interface is minimal and aimed at practical data analysis:
 - Optional integration with `pandas` data frame types (no install-time dependency)
 - Optimized algorithm and parallel processing of multiple estimation tasks
 
-This package depends only on NumPy.
+This package depends only on NumPy; Pandas is suggested for more enjoyable data analysis.
 Support for Python 3.6+ on the latest macOS, Ubuntu and Windows versions
 is officially tested.
 
-This project is still in **alpha** status and interface changes are possible.
+This project is still in **beta** status: breaking changes are unlikely but possible.
 For more information on theoretical background and usage, please see the
 [documentation](https://polsys.github.io/ennemi).
 If you encounter any problems or have suggestions, please file an issue!

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ _Partial Mutual Information for Coupling Analysis of Multivariate Time Series_,
 Physical Review Letters **99**:20 (2007),
 [doi:10.1103/PhysRevLett.99.204101](https://dx.doi.org/10.1103/PhysRevLett.99.204101).
 
-**NOTE:** This package is **alpha** quality.
-Even though the algorithm is stable, there may still be breaking changes to the API.
+**NOTE:** The package is **beta** quality.
+We are not planning major changes to the API, but breakages are still possible.
+The latest source code on GitHub might be more unstable than the released version on PyPI.
 You can see the roadmap of planned additions on the
 [Milestones page](https://github.com/polsys/ennemi/milestones).
 
@@ -28,7 +29,8 @@ You can see the roadmap of planned additions on the
 
 This package requires Python 3.6 or higher,
 and it is tested to work on the latest versions of Ubuntu, macOS and Windows.
-The only dependency is NumPy.
+The only hard dependency is a reasonably recent version of NumPy;
+Pandas is strongly suggested for more enjoyable data analysis.
 
 This package is available on PyPI:
 ```sh

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ All methods, including tests, are type annotated and checked with `mypy`.
 The CI script runs the check automatically on each pushed commit.
 To run the check yourself, execute
 ```sh
-python -m mypy --disallow-untyped-defs ennemi/ tests/unit tests/integration
+python -m mypy ennemi/ tests/unit tests/integration
 ```
+in the repository root (configuration is stored in `mypy.ini` file).
 
 Please see also the [contribution guidelines](CONTRIBUTING.md).
 

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -9,7 +9,7 @@ Do not import this module directly, but rather import the main ennemi module.
 import concurrent.futures
 from typing import List, Optional, Sequence, Tuple, TypeVar, Union
 import itertools
-import numpy as np # type: ignore
+import numpy as np
 import sys
 from ._entropy_estimators import _estimate_single_mi, _estimate_conditional_mi,\
     _estimate_single_entropy_1d, _estimate_single_entropy_nd
@@ -38,7 +38,7 @@ def normalize_mi(mi: GenArrayLike) -> GenArrayLike:
 
     # If the parameter is a pandas type, preserve the columns and indices
     if "pandas" in sys.modules:
-        import pandas # type: ignore
+        import pandas
         if isinstance(mi, (pandas.DataFrame, pandas.Series)):
             return mi.applymap(_normalize)
     

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -11,7 +11,7 @@ import bisect
 from typing import Dict, Iterator, List, Tuple, Union
 import itertools
 import math
-import numpy as np # type: ignore
+import numpy as np
 
 
 def _estimate_single_entropy_1d(x: np.ndarray, k: int = 3) -> float:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,29 @@
+[mypy]
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_unreachable = True
+
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_untyped_calls = True
+disallow_any_decorated = True
+disallow_any_explicit = True
+disallow_any_generics = True
+disallow_subclassing_any = True
+no_implicit_optional = True
+
+# We still need to disable some checks because NumPy is not annotated
+disallow_any_expr = False
+warn_return_any = False
+
+
+# Skip imports that do not have type information
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-pandas.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(description_file, encoding="utf-8") as f:
 
 setup(
     name = "ennemi",
-    version = "1.0.0alpha2",
+    version = "1.0.0beta1",
     description = "Easy-to-use Nearest Neighbor Estimation of Mutual Information",
     long_description = long_description,
     long_description_content_type = "text/markdown",
@@ -20,7 +20,7 @@ setup(
     license = "MIT",
 
     classifiers = [
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     },
 
     packages = [ "ennemi" ],
+    package_data = { "ennemi": ["py.typed"] },
     python_requires = "~=3.6",
     # At least pandas requires numpy 1.17.3+ (security fixes), we should too
     install_requires = [ "numpy>=1.17.5", "numpy<2.0" ],

--- a/tests/integration/test_censored_distribution.py
+++ b/tests/integration/test_censored_distribution.py
@@ -8,9 +8,9 @@ expects a continuous distribution. Nevertheless, ennemi seems to work fine.
 """
 
 from ennemi import estimate_mi
-from scipy.integrate import quad, dblquad # type: ignore
-from scipy.stats import norm, multivariate_normal as mvnorm # type: ignore
-import numpy as np # type: ignore
+from scipy.integrate import quad, dblquad
+from scipy.stats import norm, multivariate_normal as mvnorm
+import numpy as np
 import unittest
 
 class TestCensoredDistribution(unittest.TestCase):

--- a/tests/integration/test_entropy_identities.py
+++ b/tests/integration/test_entropy_identities.py
@@ -4,7 +4,7 @@
 """Mathematical identities for entropy and mutual information."""
 
 from ennemi import estimate_entropy, estimate_mi
-import numpy as np # type: ignore
+import numpy as np
 import unittest
 
 class TestEntropyIdentities(unittest.TestCase):

--- a/tests/integration/test_mixture_distribution.py
+++ b/tests/integration/test_mixture_distribution.py
@@ -4,9 +4,9 @@
 """A mixture distribution that has no analytical expression for MI."""
 
 from ennemi import estimate_mi
-from scipy.integrate import dblquad # type: ignore
-from scipy.stats import norm, multivariate_normal as mvnorm # type: ignore
-import numpy as np # type: ignore
+from scipy.integrate import dblquad
+from scipy.stats import norm, multivariate_normal as mvnorm
+import numpy as np
 import unittest
 
 class TestMixtureDistribution(unittest.TestCase):

--- a/tests/integration/test_pandas_workflow.py
+++ b/tests/integration/test_pandas_workflow.py
@@ -4,8 +4,8 @@
 """A simplified version of the case study in the documentation."""
 
 from ennemi import estimate_mi, pairwise_mi
-import numpy as np # type: ignore
-import pandas as pd # type: ignore
+import numpy as np
+import pandas as pd
 import unittest
 import os
 

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -5,9 +5,9 @@
 
 from itertools import product
 import math
-import numpy as np # type: ignore
+import numpy as np
 import os.path
-import pandas as pd # type: ignore
+import pandas as pd
 import random
 from typing import List
 import unittest

--- a/tests/unit/test_entropy_estimators.py
+++ b/tests/unit/test_entropy_estimators.py
@@ -5,8 +5,8 @@
 
 import math
 from math import log
-import numpy as np # type: ignore
-from scipy.special import gamma, psi # type: ignore
+import numpy as np
+from scipy.special import gamma, psi
 import unittest
 from ennemi._entropy_estimators import _estimate_single_entropy_1d,\
     _estimate_single_entropy_nd,\


### PR DESCRIPTION
Part of #41.

- Bump the version number to `1.0.0beta1`
- Update references to development status except for the GitHub page (which should reflect the currently published version)
- Add a `py.typed` file so that type annotations are visible to user code
- Move `mypy` configuration (especially `# type: ignore` comments on imports) to a file, and enable some more rules