### PR TITLE
Replace naive grid by SciPy's N-dimensional tree

### DIFF
--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -106,8 +106,7 @@ def estimate_entropy(x: ArrayLike, *, k: int = 3, multidim: bool = False,
     # Validate the parameters
     if not 1 <= x_arr.ndim <= 2:
         raise ValueError("x must be one- or two-dimensional")
-    if k <= 0:
-        raise ValueError("k must be greater than zero")
+    _validate_k_type(k)
     if k >= x_arr.shape[0]:
         raise ValueError("k must be smaller than number of observations (after lag and mask)")
     if np.any(np.isnan(x_arr)):
@@ -309,8 +308,7 @@ def _estimate_mi(y: np.ndarray, x: np.ndarray, lag: np.ndarray, k: int,
 def _check_parameters(x: np.ndarray, y: Optional[np.ndarray], k: int,
         cond: Optional[np.ndarray], mask: Optional[np.ndarray]) -> None:
     """Does most of parameter checking, but some is still left to _lagged_mi."""
-    if k <= 0:
-        raise ValueError("k must be greater than zero")
+    _validate_k_type(k)
 
     # Validate the array shapes and lengths
     if not 1 <= len(x.shape) <= 2:
@@ -324,6 +322,12 @@ def _check_parameters(x: np.ndarray, y: Optional[np.ndarray], k: int,
     # Validate the mask and condition
     if mask is not None: _validate_mask(mask, x.shape[0])
     if cond is not None: _validate_cond(cond, x.shape[0])
+
+def _validate_k_type(k: int) -> None:
+    if not isinstance(k, int):
+        raise TypeError("k must be int")
+    if k <= 0:
+        raise ValueError("k must be greater than zero")
 
 def _validate_mask(mask: np.ndarray, input_len: int) -> None:
     if len(mask.shape) > 1:

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -7,11 +7,8 @@ Do not import this module directly.
 Use the `estimate_mi` method in the main ennemi module instead.
 """
 
-import bisect
-from typing import Dict, Iterator, List, Tuple, Union
-import itertools
-import math
 import numpy as np
+from scipy.spatial import cKDTree
 
 
 def _estimate_single_entropy_1d(x: np.ndarray, k: int = 3) -> float:
@@ -60,16 +57,14 @@ def _estimate_single_entropy_nd(x: np.ndarray, k: int = 3) -> float:
     """
 
     N, ndim = x.shape
-    grid = _BoxGridND(x, k)
+    grid = cKDTree(x, k)
     distances = np.empty(N)
 
     # Search for the k'th neighbor of each point and store the distance
     for i in range(N):
-        cur_x = x[i,0]
-        cur_y = x[i,1]
-        cur_z = x[i,2:]
+        point = x[i]
         
-        distances[i] = _find_kth_neighbor_nd(k, grid, cur_x, cur_y, cur_z)
+        distances[i] = np.max(grid.query(point, k=k+1, p=np.inf)[0])
 
     # The log(2) term is because the mean is taken over double the distances
     return _psi(N) - _psi(k) + ndim * (np.mean(np.log(distances)) + np.log(2))
@@ -98,31 +93,25 @@ def _estimate_single_mi(x: np.ndarray, y: np.ndarray, k: int = 3) -> float:
 
     N = len(x)
 
-    # We use the fastest O(N*sqrt(k)) time algorithm, based on boxes
-    # Create the 2D grid for finding the k-th neighbor
-    grid = _BoxGrid2D(x, y, k)
+    # Ensure that x and y are is 2-dimensional
+    x = np.column_stack((x,))
+    y = np.column_stack((y,))
 
-    # Sort the observation arrays
-    # These arrays is used for finding the axis neighbors by binary search
-    xs = np.sort(x)
-    ys = np.sort(y)
+    # We use the fastest O(N*sqrt(k)) time algorithm
+    # Create the 2D tree for finding the k-th neighbor and marginal 1D trees
+    xy = np.column_stack((x, y))
 
-    # Go through all observations
-    nx = np.empty(N, np.int32)
-    ny = np.empty(N, np.int32)
+    grid = cKDTree(xy)
+    x_grid = cKDTree(x)
+    y_grid = cKDTree(y)
 
-    for i in range(0, N):
-        cur_x = x[i]
-        cur_y = y[i]
-
-        eps = _find_kth_neighbor_2d(k, grid, cur_x, cur_y)
-
-        # Now eps contains the distance to the k'th neighbor
-        # Find the number of x and y neighbors within that distance
-        # This also includes the element itself but that cancels out in the
-        # formula of Kraskov et al.
-        nx[i] = _count_within_1d(xs, cur_x - eps, cur_x + eps)
-        ny[i] = _count_within_1d(ys, cur_y - eps, cur_y + eps)
+    # We have to subtract a small value from the radius
+    # because the algorithm expects strict inequality but cKDTree also allows equality.
+    # This assumes that the radius is of roughly unit magnitude.
+    # TODO: Try to get Kraskov et al. estimator 2 working.
+    eps = grid.query(xy, k=[k+1], p=np.inf)[0].flatten()
+    nx = x_grid.query_ball_point(x, eps - 1e-12, p=np.inf, return_length=True)
+    ny = y_grid.query_ball_point(y, eps - 1e-12, p=np.inf, return_length=True)
 
     # Calculate the estimate
     return _psi(N) + _psi(k) - np.mean(_psi(nx) + _psi(ny))
@@ -141,351 +130,34 @@ def _estimate_conditional_mi(x: np.ndarray, y: np.ndarray, cond: np.ndarray,
     Physical Review Letters 99. doi:10.1103/PhysRevLett.99.204101
     """
 
-    N = len(x)
+    # Ensure that cond is 2-dimensional
+    cond = np.column_stack((cond,))
 
-    # This is a straightforward extension of estimate_single_mi,
-    # except that we use N-dimensional grids everywhere.
-    # The boxes are larger than in the unconditional case because of NumPy
-    # vectorization. The Z projection has a special case for 1-dimensional
-    # condition as the generic code is much slower.
-    full_grid = _BoxGridND(np.column_stack((x, y, cond)), 10*k)
-    if cond.ndim == 1:
-        z_array = np.sort(cond)
-    else:
-        z_grid = _BoxGridND(np.column_stack((cond,)), 50*k)
-    xz_grid = _BoxGridND(np.column_stack((x, cond)), 50*k)
-    yz_grid = _BoxGridND(np.column_stack((y, cond)), 50*k)
+    # The cKDTree class offers a lot of vectorization
+    # First, create N-dimensional trees for variables
+    xyz = np.column_stack((x, y, cond))
+    full_grid = cKDTree(xyz)
 
-    nxz = np.empty(N, np.int32)
-    nyz = np.empty(N, np.int32)
-    nz = np.empty(N, np.int32)
+    xz_grid = cKDTree(np.column_stack((x, cond)))
+    yz_grid = cKDTree(np.column_stack((y, cond)))
+    z_grid = cKDTree(cond)
 
-    for i in range(0, N):
-        cur_x = x[i]
-        cur_y = y[i]
-        cur_z = cond[i]
+    # Find the distance to the k'th neighbor of each point
+    eps = full_grid.query(xyz, k=[k+1], p=np.inf)[0].flatten()
 
-        eps = _find_kth_neighbor_nd(k, full_grid, cur_x, cur_y, cur_z)
+    # Find the number of neighbors in marginal spaces
+    xz_proj = np.column_stack((x, cond))
+    yz_proj = np.column_stack((y, cond))
 
-        # Count the number of marginal neighbors using the projected grids
-        if cond.ndim == 1:
-            nz[i] = _count_within_1d(z_array, cur_z - eps, cur_z + eps)
-        else:
-            nz[i] = _count_within_nd(z_grid, cur_z, eps)
-        
-        xz_proj = np.concatenate(([cur_x], np.atleast_1d(cur_z)))
-        nxz[i] = _count_within_nd(xz_grid, xz_proj, eps)
-        yz_proj = np.concatenate(([cur_y], np.atleast_1d(cur_z)))
-        nyz[i] = _count_within_nd(yz_grid, yz_proj, eps)
+    # We have to subtract a small value from the radius
+    # because the algorithm expects strict inequality but cKDTree also allows equality.
+    # This assumes that the radius is of roughly unit magnitude.
+    # TODO: Try to get Kraskov et al. estimator 2 adapted to this case.
+    nxz = xz_grid.query_ball_point(xz_proj, eps - 1e-12, p=np.inf, return_length=True)
+    nyz = yz_grid.query_ball_point(yz_proj, eps - 1e-12, p=np.inf, return_length=True)
+    nz = z_grid.query_ball_point(cond, eps - 1e-12, p=np.inf, return_length=True)
 
     return _psi(k) - np.mean(_psi(nxz) + _psi(nyz) - _psi(nz))
-
-
-def _find_kth_neighbor_2d(k: int, grid: "_BoxGrid2D", cur_x: float, cur_y: float) -> float:
-    # Start with the box containing the point. Then until we have found
-    # enough neighbors, extend the rectangle to the most potential direction.
-    # We should not go like peeling an onion because the boxes are not
-    # regularly spaced.
-    #
-    # So, the search order could look like this:
-    # +----------+---+-------+-----------+--------+
-    # |          |   |       |           |        |
-    # |    6     | 6 | 6     |    6      |   7    |
-    # +-------------------------------------------+
-    # |          |   |       |           |        |
-    # |    4     | 3 | 3     |    5      |   7    |
-    # +-------------------------------------------+
-    # |          |   |       |           |        |
-    # |          |   |       |           |        |
-    # |    4     | 1 | x 0   |    5      |   7    |
-    # |          |   |       |           |        |
-    # +-------------------------------------------+
-    # |    4     | 2 |  2    |    5      |   7    |
-    # +----------+---+-------+-----------+--------+
-    # where x is (cur_x, cur_y). Of course, the search would stop as soon
-    # as extending further would provide no more benefit.
-
-    eps = np.inf
-    distances = np.full(k, eps)
-
-    # First go through the points in the current box
-    box_x, box_y = grid.find_box(cur_x, cur_y)
-    eps = _update_epsilon_2d(distances, eps, cur_x, cur_y, grid.boxes[box_x, box_y])
-
-    # Then extend to the most promising direction as long as necessary    
-    left = right = box_x
-    down = up = box_y
-    M = grid.xy_boxes - 1
-
-    while not (left == 0 and right == M and down == 0 and up == M):
-
-        # Find the direction where the edge is the closest
-        edge_dist = np.full(4, np.inf)
-        if left > 0: edge_dist[0] = cur_x - grid.x_splits[left]
-        if right < M: edge_dist[1] = grid.x_splits[right+1] - cur_x
-        if down > 0: edge_dist[2] = cur_y - grid.y_splits[down]
-        if up < M: edge_dist[3] = grid.y_splits[up+1] - cur_y
-
-        direction = edge_dist.argmin()
-
-        # If all the points in that direction are further away
-        # than the points found so far, we are done
-        if eps <= edge_dist[direction]:
-            return eps
-
-        # Otherwise, extend the rectangle to that direction and go through
-        # all the boxes that form the added edge
-        if direction == 0:
-            # Go left
-            left -= 1
-            for j in range(down, up+1):
-                eps = _update_epsilon_2d(distances, eps, cur_x, cur_y, grid.boxes[left, j])
-        elif direction == 1:
-            # Go right
-            right += 1
-            for j in range(down, up+1):
-                eps = _update_epsilon_2d(distances, eps, cur_x, cur_y, grid.boxes[right, j])
-        elif direction == 2:
-            # Go down
-            down -= 1
-            for i in range(left, right+1):
-                eps = _update_epsilon_2d(distances, eps, cur_x, cur_y, grid.boxes[i, down])
-        elif direction == 3:
-            # Go up
-            up += 1
-            for i in range(left, right+1):
-                eps = _update_epsilon_2d(distances, eps, cur_x, cur_y, grid.boxes[i, up])
-
-    # This is reachable if the space contains just one box
-    return eps
-
-
-def _update_epsilon_2d(distances: np.ndarray, eps: float,
-        cur_x: float, cur_y: float, box: "_Box2D") -> float:
-    for (x, y) in box:
-        dist = max(abs(cur_x - x), abs(cur_y - y))
-
-        # Do not count the point itself
-        if 0 < dist < eps:
-            # Replace the largest distance in the array, then re-sort
-            distances[len(distances)-1] = dist
-            distances.sort()
-            eps = distances.max()
-    
-    return eps
-
-
-def _count_within_1d(array: List[float], lower: float, upper: float) -> int:
-    """Returns the number of elements between lower and upper (exclusive).
-
-    The array must be sorted as a binary search will be used.
-    This algorithm has O(log n) time complexity.
-    """
-
-    # The bisect module provides two methods for adding items to sorted arrays:
-    # bisect_left gives insertion point BEFORE duplicates and bisect_right gives
-    # insertion point AFTER duplicates. We can just check where the two limits
-    # would be added and this gives us our range.
-    left = bisect.bisect_right(array, lower)
-    right = bisect.bisect_left(array, upper)
-
-    # The interval is strictly between left and right
-    # In case of duplicate entries it is possible that right < left
-    return max(right - left, 0)
-
-
-def _find_kth_neighbor_nd(k: int, grid: "_BoxGridND",
-        cur_x: float, cur_y: float, cur_z: Union[float, np.ndarray]) -> float:
-    # The same principle as in the 2D case, but with more dimensions.
-    # Because the number of dimensions is arbitrary, the code is more generic.
-    # The searched box is stored as [min_x, max_x, min_y, max_y, ...] so
-    # that even indices are minimum (left, down, ...) and odd maximum coordinates.
-
-    distances = np.full(k, np.inf)
-
-    # First go through the points in the current box
-    cur_point = np.concatenate(([cur_x], [cur_y], np.atleast_1d(cur_z)))
-    box_coords = grid.find_box(cur_point)
-    distances = _update_epsilon_nd(distances, cur_point, grid.boxes[box_coords])
-
-    # Then extend to the most promising direction as long as necessary
-    bounds = np.repeat(box_coords, 2)
-    M = grid.xyz_boxes - 1
-    full_space = np.tile((0, M), grid.ndim)
-
-    while not np.array_equal(bounds, full_space):
-
-        # Find the direction where the edge is the closest
-        edge_dist = np.full(2 * grid.ndim, np.inf)
-        for i in range(grid.ndim):
-            left = bounds[2*i]
-            right = bounds[2*i + 1]
-            if left > 0: edge_dist[2*i] = cur_point[i] - grid.splits[left,i]
-            if right < M: edge_dist[2*i+1] = grid.splits[right+1,i] - cur_point[i]
-
-        direction = edge_dist.argmin()
-
-        # If all the points in that direction are further away
-        # than the points found so far, we are done
-        if distances[k-1] <= edge_dist[direction]:
-            return distances[k-1]
-
-        # Otherwise, extend the rectangle to that direction and go through
-        # all the boxes that form the added edge
-        if direction % 2 == 0:
-            # Even: move "left"
-            fixed_point = bounds[direction] - 1
-        else:
-            # Odd: move "right"
-            fixed_point = bounds[direction] + 1
-        bounds[direction] = fixed_point
-
-        # Loop through all the boxes on the new face.
-        # To do this, we keep the changed coordinate fixed and loop through
-        # all others. To do so, we need to build a list of iterators
-        # for itertools.product() first.
-        iters = [] # type: List[Union[List[int], range]]
-        for i in range(grid.ndim):
-            if i == direction // 2:
-                iters.append([fixed_point])
-            else:
-                iters.append(range(bounds[i*2], bounds[i*2+1] + 1))
-        for coord in itertools.product(*iters):
-            distances = _update_epsilon_nd(distances, cur_point, grid.boxes[coord])
-
-    # This is reachable if the space contains just one box
-    return distances[k-1]
-
-
-def _update_epsilon_nd(distances: List[float], cur_point: np.ndarray,
-        box: np.ndarray) -> List[float]:
-    # The distances array is assumed to be sorted
-    point_count = len(distances)
-    eps = distances[point_count - 1]
-
-    if box.size == 0:
-        return distances
-    
-    # This is NumPy vectorized
-    # Take the points that are closer than eps, but not the point itself
-    box_dists = np.max(np.abs(box - cur_point), axis=1)
-    box_dists = box_dists[(0 < box_dists) & (box_dists < eps)]
-
-    if box_dists.size == 0:
-        return distances
-
-    distances = np.append(distances, box_dists, axis=0)
-    distances.sort()
-    return distances[:point_count]
-
-
-def _count_within_nd(grid: "_BoxGridND", center: np.ndarray, eps: float) -> int:
-    # Go through all the boxes that may contain neighbors
-    min_coord = grid.find_box(center - eps)
-    max_coord = grid.find_box(center + eps)
-
-    # Create a list of iterators for itertools.product()
-    iters = [range(max(min_coord[i], 0), min(max_coord[i]+1, grid.xyz_boxes)) for i in range(grid.ndim)]
-
-    # Count the close enough points in every box
-    # This is vectorized with NumPy and as such the boxes should be large
-    result = 0
-    for box_coord in itertools.product(*iters):
-        points = grid.boxes[box_coord]
-        if points.size == 0:
-            continue
-
-        dists = np.max(np.abs(points - center), axis=1)
-        result += np.sum(dists < eps)
-    return result
-
-
-#
-# Grid types
-#
-
-_Box2D = List[Tuple[float, float]]
-
-class _BoxGrid2D:
-    """A helper for accessing a two-dimensional space in smaller blocks."""
-
-    def __init__(self, x: np.ndarray, y: np.ndarray, k: int):
-        # Each box contains k points on average
-        # (Benchmarked to be better than 2*k or 4*k)
-        split_size = int(math.sqrt(k * len(x)))
-        xy_boxes = math.ceil(len(x) / split_size)
-
-        # Store the boxes in a dictionary keyed by block coordinates
-        self.xy_boxes = xy_boxes
-        self.boxes = {} # type: Dict[Tuple[int, int], _Box2D]
-        for i in range(xy_boxes):
-            for j in range(xy_boxes):
-                    self.boxes[(i,j)] = []
-
-        # Now the real initialization: first find the split points
-        self.x_splits = np.sort(x)[0:len(x):split_size]
-        self.y_splits = np.sort(y)[0:len(x):split_size]
-        
-        # Then assign points to boxes based on those
-        for i in range(len(x)):
-            box_x, box_y = self.find_box(x[i], y[i])
-            self.boxes[(box_x, box_y)].append((x[i], y[i]))
-
-
-    def find_box(self, x: float, y: float) -> Tuple[int, int]:
-        # The box index to use is the index of the largest split point
-        # smaller than the coordinate. This is easy to get with bisect,
-        # we just need to offset by one.
-        # This algorithm is O(log n).
-        box_x = bisect.bisect(self.x_splits, x) - 1
-        box_y = bisect.bisect(self.y_splits, y) - 1
-        return (box_x, box_y)
-
-
-class _BoxGridND:
-    """A helper for accessing an N-dimensional space in smaller blocks."""
-
-    def __init__(self, points: np.ndarray, k: int):
-        nobs, ndim = points.shape
-        self.ndim = ndim
-
-        # For each box to contain k points on average, the marginal
-        # splits must contain N/k points on average
-        split_size = int(math.pow(nobs, (ndim-1)/ndim) * math.pow(k, 1/ndim))
-        xyz_boxes = math.ceil(nobs / split_size)
-
-        # Store the boxes in a dictionary keyed by block coordinates
-        self.xyz_boxes = xyz_boxes
-        self.boxes = {} # type: Dict[Tuple[int, ...], np.ndarray]
-        for coord in itertools.product(range(xyz_boxes), repeat=ndim):
-            self.boxes[coord] = []
-
-        # Now the real initialization: first find the split points
-        self.splits = np.empty((xyz_boxes, ndim))
-        for i in range(ndim):
-            self.splits[:,i] = np.sort(points[:,i])[0:nobs:split_size]
-        
-        # Then assign points to boxes based on those
-        for i in range(nobs):
-            coord = self.find_box(points[i])
-            self.boxes[coord].append(points[i])
-
-        # Convert all the boxes to ndarrays
-        for key in self.boxes:
-            self.boxes[key] = np.asarray(self.boxes[key])
-
-
-    def find_box(self, point: np.ndarray) -> Tuple[int, ...]:
-        # The box index to use is the index of the largest split point
-        # smaller than the coordinate. This is easy to get with bisect,
-        # we just need to offset by one.
-        # This algorithm is O(log n).
-        coord = []
-        point = np.atleast_1d(point)
-        for i in range(self.ndim):
-            coord.append(bisect.bisect(self.splits[:,i], point[i]) - 1)
-        return tuple(coord)
-
 
 #
 # Digamma
@@ -494,22 +166,20 @@ class _BoxGridND:
 def _psi(x: np.ndarray) -> np.ndarray:
     """A replacement for scipy.special.psi, for non-negative integers only.
     
-    This is up to a few times slower than the SciPy version, but it's not fun
-    to depend on full SciPy just for this method (even though SciPy is often
-    installed with NumPy). This method is not the bottleneck anyways, so the
-    difference vanishes in the measurement noise.
+    This is slightly faster than the SciPy version (not that it's a bottleneck),
+    and has consistent behavior for digamma(0).
     """
     
     x = np.asarray(x)
 
     # psi(0) = inf for SciPy compatibility
-    result = np.full(x.shape, np.inf)
-    mask = (x != 0)
+    # The shape of result does not matter as inf will propagate in mean()
+    if np.any(x == 0):
+        return np.inf
 
     # Use the SciPy value for psi(1), because the expansion is not good enough
-    one_mask = (x == 1)
-    result[one_mask] = -0.5772156649015331
-    mask = mask & ~one_mask
+    mask = (x != 1)
+    result = np.full(x.shape, -0.5772156649015331)
 
     # For the rest, a good enough expansion is given by
     # https://www.uv.es/~bernardo/1976AppStatist.pdf

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ setup(
     package_data = { "ennemi": ["py.typed"] },
     python_requires = "~=3.6",
     # At least pandas requires numpy 1.17.3+ (security fixes), we should too
-    install_requires = [ "numpy>=1.17.5", "numpy<2.0" ],
+    install_requires = [ "numpy>=1.17.5", "numpy<2.0", "scipy~=1.4" ],
     extras_require = {
-        "dev": ["scipy~=1.4", "pandas~=1.0", "pytest~=5.4", "mypy~=0.770"]
+        "dev": [ "pandas~=1.0", "pytest~=5.4", "mypy~=0.770" ]
     }
 )

--- a/tests/unit/test_entropy_estimators.py
+++ b/tests/unit/test_entropy_estimators.py
@@ -105,7 +105,7 @@ class TestEstimateSingleMi(unittest.TestCase):
 
     def test_bivariate_gaussian(self) -> None:
         cases = [ (0, 40, 3, 0.1),
-                  (0, 200, 3, 0.05),
+                  (0, 200, 3, 0.06),
                   (0, 2000, 3, 0.005),
                   (0, 2000, 5, 0.006),
                   (0, 2000, 20, 0.003),


### PR DESCRIPTION
Closes #21.

Start depending on SciPy. I was initially ignorant of `cKDTree` (embarrassing, yes, but such things happen), and even after learning about it, it provided smaller benefits than Numba. However, I was looking at the API docs for `KDTree`, an implementation in pure Python. SciPy docs do not highlight that the Cython implementation has some extra features. These allow massive offloading of work to native code.

On my laptop, some selected benchmark results (note that there were multiple apps open, but the level of noise hardly matters here):

| Benchmark | Previous min | Current min
| -- | -- | --
| Large sample MI | 2.84 s | 0.162 s
| MI, N=100 | 0.078 s | 0.0211 s
| MI, N=1600 | 0.794 s | 0.0612 s
| CMI, N=1600 | 3.46 s | 0.102 s
| CMI2, N=1600 | 4.29 s | 0.137 s

Additionally, the algorithm is now `O(sqrt(k) * N)` and not `O(k * N)`.