### PR TITLE
Improve parallelism implementation

### DIFF
--- a/benchmarks/bench_entropy.py
+++ b/benchmarks/bench_entropy.py
@@ -16,18 +16,24 @@ cov = np.array([
     [ 0.5,  1.0,  0.7, -0.5],
     [ 0.6,  0.7,  2.0, -0.1],
     [-0.2, -0.5, -0.1,  0.5]])
-data = rng.multivariate_normal([0, 0, 0, 0], cov, size=4000)
+data = rng.multivariate_normal([0, 0, 0, 0], cov, size=16000)
 """
 
 bench_1d = "estimate_entropy(data[:N,0], k=3)"
+bench_2d = "estimate_entropy(data[:N,:2], k=3, multidim=True)"
 bench_4d = "estimate_entropy(data[:N,:], k=3, multidim=True)"
 bench_independent = "estimate_entropy(data[:N,:], k=3)"
-bench_cond = "estimate_entropy(data[:N,:3], k=3, cond=data[:N,3])"
+bench_cond_2d = "estimate_entropy(data[:N,:2], k=3, cond=data[:N,3])"
+bench_cond_2x2d = "estimate_entropy(data[:N,:2], k=3, cond=data[:N,2:])"
+bench_independent_cond = "estimate_entropy(data[:N,:3], k=3, cond=data[:N,3])"
 
 for (name, bench) in [ ("1D", bench_1d),
                        ("4x1D", bench_independent),
+                       ("2D", bench_2d),
                        ("4D", bench_4d),
-                       ("Cond 3x1D", bench_cond) ]:
-    for n in [ 250, 1000, 4000 ]:
+                       ("Cond 2D", bench_cond_2d),
+                       ("Cond 2D+2D", bench_cond_2x2d),
+                       ("Cond 3x1D", bench_independent_cond) ]:
+    for n in [ 1000, 4000, 16000 ]:
         res = timeit.repeat(bench, setup, repeat=5, number=1, globals={"N": n})
-        print(f"{name:>9}, N={n:<4}: min={np.min(res):<6.3} s, mean={np.mean(res):<6.3} s")
+        print(f"{name:>10}, N={n:>5}: min={np.min(res):<6.3} s, mean={np.mean(res):<6.3} s")

--- a/benchmarks/bench_large_sample_mi.py
+++ b/benchmarks/bench_large_sample_mi.py
@@ -16,12 +16,15 @@ import numpy as np
 
 rng = np.random.default_rng(0)
 cov = np.array([[1, 0.8], [0.8, 1]])
-data = rng.multivariate_normal([0, 0], cov, size=20000)
+data = rng.multivariate_normal([0, 0], cov, size=N)
 
 x = data[:,0]
 y = data[:,1]
 """
 
-bench = "estimate_mi(y, x, k=8)"
-res = timeit.repeat(bench, setup, repeat=5, number=1)
-print(f"N=20000, k=8: min={np.min(res):<6.3} s, mean={np.mean(res):<6.3} s")
+bench = "estimate_mi(y, x, k=k)"
+
+for (N, k) in [(20000, 8), (20000, 50), (100000, 8)]:
+    res = timeit.repeat(bench, setup, repeat=5, number=1,
+        globals={"N": N, "k": k})
+    print(f"N={N:>6}, k={k:>2}: min={np.min(res):<6.3} s, mean={np.mean(res):<6.3} s")

--- a/benchmarks/bench_mutual_information.py
+++ b/benchmarks/bench_mutual_information.py
@@ -31,6 +31,6 @@ cmi2_bench = "estimate_mi(d, data, lag=[-1, 0, 1, 2], k=3, cond=cond2)"
 for (name, bench) in [ ("MI", mi_bench),
                        ("CMI", cmi_bench),
                        ("CMI2", cmi2_bench) ]:
-    for n in [ 100, 400, 1600 ]:
+    for n in [ 100, 400, 1600, 6400 ]:
         res = timeit.repeat(bench, setup, repeat=5, number=1, globals={"N": n})
         print(f"{name:<4}, N={n:<4}: min={np.min(res):<6.3} s, mean={np.mean(res):<6.3} s")

--- a/benchmarks/bench_pairwise_mi.py
+++ b/benchmarks/bench_pairwise_mi.py
@@ -27,6 +27,6 @@ cmi_bench = "pairwise_mi(data, k=3, cond=e)"
 
 for (name, bench) in [ ("MI", mi_bench),
                        ("CMI", cmi_bench) ]:
-    for n in [ 100, 400, 1600 ]:
+    for n in [ 100, 400, 1600, 6400 ]:
         res = timeit.repeat(bench, setup, repeat=5, number=1, globals={"N": n})
         print(f"{name:<3}, N={n:<4}: min={np.min(res):<6.3} s, mean={np.mean(res):<6.3} s")

--- a/docs/kaisaniemi.md
+++ b/docs/kaisaniemi.md
@@ -118,7 +118,7 @@ plt.show()
 ![Now the day of year correlations are zero and most other correlations reduced.
 There remain correlations between temperature, dew point and wind direction.](casestudy_pairwise_doy.png)
 
-As a sanity check, the correlations with day of year are now zero.
+As a consistency check, the correlations with day of year are now zero.
 (With unscaled data, there would actually remain quite significant noise.)
 The correlation between air pressure and temperature is now weaker,
 suggesting that it was partly caused by seasonal cycles of the two variables.

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -14,7 +14,7 @@ import numpy as np
 from os import cpu_count
 import sys
 from ._entropy_estimators import _estimate_single_mi, _estimate_conditional_mi,\
-    _estimate_single_entropy_1d, _estimate_single_entropy_nd
+    _estimate_single_entropy
 
 ArrayLike = Union[List[float], List[Tuple[float, ...]], np.ndarray]
 GenArrayLike = TypeVar("GenArrayLike", List[float], List[Tuple[float, ...]], np.ndarray)
@@ -137,12 +137,12 @@ def _estimate_entropy(x: np.ndarray, k: int, multidim: bool) -> np.ndarray:
     """Strongly typed estimate_entropy()."""
 
     if multidim and x.ndim > 1:
-        return np.asarray(_estimate_single_entropy_nd(x, k))
+        return np.asarray(_estimate_single_entropy(x, k))
     elif x.ndim == 1:
-        return np.asarray(_estimate_single_entropy_1d(x, k))
+        return np.asarray(_estimate_single_entropy(x, k))
     else:
         nvar = x.shape[1]
-        return np.asarray([_estimate_single_entropy_1d(x[:,i], k) for i in range(nvar)])
+        return np.asarray([_estimate_single_entropy(x[:,i], k) for i in range(nvar)])
 
 
 def _estimate_conditional_entropy(x: np.ndarray, cond: np.ndarray, k: int, multidim: bool) -> np.ndarray:
@@ -154,12 +154,12 @@ def _estimate_conditional_entropy(x: np.ndarray, cond: np.ndarray, k: int, multi
     # The joint entropy depends on multidim and number of dimensions:
     # In the latter case, the joint entropy is calculated for each x variable
     if multidim or x.ndim == 1:
-        joint = _estimate_single_entropy_nd(np.column_stack((x, cond)), k)
+        joint = _estimate_single_entropy(np.column_stack((x, cond)), k)
         return np.asarray(joint - marginal)
     else:
         nvar = x.shape[1]
         joint = np.asarray(
-            [_estimate_single_entropy_nd(np.column_stack((x[:,i], cond)), k) for i in range(nvar)])
+            [_estimate_single_entropy(np.column_stack((x[:,i], cond)), k) for i in range(nvar)])
         return joint - marginal
 
 

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -11,60 +11,26 @@ import numpy as np
 from scipy.spatial import cKDTree
 
 
-def _estimate_single_entropy_1d(x: np.ndarray, k: int = 3) -> float:
-    """Estimate the differential entropy of a one-dimensional random variable.
-
-    Returns the estimated entropy in nats.
-    The calculation is described in Kraskov et al. (2004): Estimating mutual
-    information. Physical Review E 69. doi:10.1103/PhysRevE.69.066138
-    """
-
-    N = x.shape[0]
-    xs = np.sort(x)
-    distances = np.empty(N)
-
-    # Search for the k'th neighbor of each point and store the distance
-    for i in range(N):
-        left = i - 1
-        right = i + 1
-        eps = np.inf
-        for _ in range(k):
-            if left >= 0: ldist = np.abs(xs[i] - xs[left])
-            else: ldist = np.inf
-            if right < N: rdist = np.abs(xs[i] - xs[right])
-            else: rdist = np.inf
-
-            if ldist < rdist:
-                eps = ldist
-                left -= 1
-            else:
-                eps = rdist
-                right += 1
-        distances[i] = eps
-
-    # The log(2) term is because the mean is taken over double the distances
-    return _psi(N) - _psi(k) + np.mean(np.log(distances)) + np.log(2)
-
-
-def _estimate_single_entropy_nd(x: np.ndarray, k: int = 3) -> float:
+def _estimate_single_entropy(x: np.ndarray, k: int = 3) -> float:
     """Estimate the differential entropy of a n-dimensional random variable.
 
     `x` must be a 2D array with columns denoting the variable dimensions.
+    1D arrays are promoted to 2D correctly.
 
     Returns the estimated entropy in nats.
     The calculation is described in Kraskov et al. (2004): Estimating mutual
     information. Physical Review E 69. doi:10.1103/PhysRevE.69.066138
     """
+
+    if x.ndim == 1:
+        x = x.reshape((x.size,1))
 
     N, ndim = x.shape
     grid = cKDTree(x, k)
     distances = np.empty(N)
 
     # Search for the k'th neighbor of each point and store the distance
-    for i in range(N):
-        point = x[i]
-        
-        distances[i] = np.max(grid.query(point, k=k+1, p=np.inf)[0])
+    distances = grid.query(x, k=[k+1], p=np.inf)[0].flatten()
 
     # The log(2) term is because the mean is taken over double the distances
     return _psi(N) - _psi(k) + ndim * (np.mean(np.log(distances)) + np.log(2))

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -385,13 +385,6 @@ class TestEstimateMi(unittest.TestCase):
             estimate_mi(y, x, mask=mask)
         self.assertEqual(str(cm.exception), INVALID_MASK_TYPE_MSG)
 
-    def test_unknown_parallel_parameter(self) -> None:
-        x = [1, 2, 3, 4]
-        y = [5, 6, 7, 8]
-
-        with self.assertRaises(ValueError):
-            estimate_mi(y, x, parallel="whatever")
-
     def test_two_covariates_without_lag(self) -> None:
         rng = np.random.default_rng(0)
         x1 = rng.uniform(0, 1, 100)
@@ -486,10 +479,9 @@ class TestEstimateMi(unittest.TestCase):
         data_path = os.path.join(script_path, "example_data.csv")
         data = np.loadtxt(data_path, delimiter=",", skiprows=1)
 
-        parallel_modes = [ None, "always", "disable" ]
-        for parallel in parallel_modes:
-            with self.subTest(parallel=parallel):
-                actual = estimate_mi(data[:,0], data[:,1:4], lag=[0, 1, 3], parallel=parallel)
+        for max_threads in [ None, 1, 2 ]:
+            with self.subTest(max_threads=max_threads):
+                actual = estimate_mi(data[:,0], data[:,1:4], lag=[0, 1, 3], max_threads=max_threads)
 
                 # The returned object is a plain ndarray
                 self.assertIsInstance(actual, np.ndarray)

--- a/tests/unit/test_entropy_estimators.py
+++ b/tests/unit/test_entropy_estimators.py
@@ -8,8 +8,7 @@ from math import log
 import numpy as np
 from scipy.special import gamma, psi
 import unittest
-from ennemi._entropy_estimators import _estimate_single_entropy_1d,\
-    _estimate_single_entropy_nd,\
+from ennemi._entropy_estimators import _estimate_single_entropy,\
     _estimate_single_mi, _estimate_conditional_mi
 
 
@@ -28,7 +27,7 @@ class TestEstimateSingleEntropy(unittest.TestCase):
                 rng = np.random.default_rng(0)
                 x = rng.normal(0, sd, size=n)
 
-                actual = _estimate_single_entropy_1d(x, k=k)
+                actual = _estimate_single_entropy(x, k=k)
                 expected = 0.5 * log(2 * math.pi * math.e * sd**2)
                 self.assertAlmostEqual(actual, expected, delta=delta)
 
@@ -42,7 +41,7 @@ class TestEstimateSingleEntropy(unittest.TestCase):
                 rng = np.random.default_rng(1)
                 x = rng.uniform(a, b, size=n)
 
-                actual = _estimate_single_entropy_1d(x, k=k)
+                actual = _estimate_single_entropy(x, k=k)
                 expected = log(b - a)
                 self.assertAlmostEqual(actual, expected, delta=delta)
 
@@ -61,7 +60,7 @@ class TestEstimateSingleEntropy(unittest.TestCase):
                 cov = np.array([[var1, rho], [rho, 1]])
                 data = rng.multivariate_normal([0, 0], cov, size=n)
 
-                actual = _estimate_single_entropy_nd(data, k=k)
+                actual = _estimate_single_entropy(data, k=k)
                 expected = 0.5 * log(np.linalg.det(2 * math.pi * math.e * cov))
                 self.assertAlmostEqual(actual, expected, delta=delta)
 
@@ -74,7 +73,7 @@ class TestEstimateSingleEntropy(unittest.TestCase):
             [-0.2, -0.5, -0.1,  0.5]])
         data = rng.multivariate_normal([0, 0, 0, 0], cov, size=2000)
 
-        actual = _estimate_single_entropy_nd(data, k=3)
+        actual = _estimate_single_entropy(data, k=3)
         expected = 0.5 * log(np.linalg.det(2 * math.pi * math.e * cov))
         self.assertAlmostEqual(actual, expected, delta=0.05)
 
@@ -92,8 +91,8 @@ class TestEstimateSingleEntropy(unittest.TestCase):
         x2 = rng.exponential(x1 * t)
         data = np.asarray([x1, x2]).T
 
-        raw = _estimate_single_entropy_nd(data)
-        trans = _estimate_single_entropy_nd(np.log(data))
+        raw = _estimate_single_entropy(data)
+        trans = _estimate_single_entropy(np.log(data))
 
         # The estimate with unlogarithmed data is very bad
         expected = 1 + s - s*psi(s) + log(gamma(s)) - log(t)


### PR DESCRIPTION
Closes #45, closes #22 and closes #23.

- Move from multiprocess parallelism to multithreading. This is possible because `cKDTree` releases the GIL during native calls. With multiprocess parallelism, data transfer started to be the bottleneck.
- Breaking change: replace the `parallel` parameter with `max_threads`.
- Tweak the heuristic for using one or many threads. The idea is to avoid the thread startup cost with small tasks.
- Instead of vectorizing the entropy estimation, just make it so fast that it does not matter. It should not be too hard to vectorize it later, but it's not high priority.
- Support passing a `callback` parameter to the parallelized methods. This enables e.g. progress bars.