### PR TITLE
Implement discrete-continuous MI

### DIFF
--- a/benchmarks/bench_mutual_information.py
+++ b/benchmarks/bench_mutual_information.py
@@ -19,6 +19,7 @@ c = rng.normal(2, 5, size=N)
 d = rng.gamma(1.0, 1.0, size=N)
 e = b + 2.0*c
 f = c + 2.0*d
+s = np.sign(d)
 
 data = np.asarray([a, b, c]).T
 cond2 = np.asarray([e, f]).T
@@ -27,10 +28,14 @@ cond2 = np.asarray([e, f]).T
 mi_bench = "estimate_mi(d, data, lag=[-1, 0, 1, 2], k=3)"
 cmi_bench = "estimate_mi(d, data, lag=[-1, 0, 1, 2], k=3, cond=e)"
 cmi2_bench = "estimate_mi(d, data, lag=[-1, 0, 1, 2], k=3, cond=cond2)"
+dmi_bench = "estimate_mi(s, data, lag=[-1, 0, 1, 2], k=3, discrete_y=True)"
+dcmi_bench = "estimate_mi(s, data, lag=[-1, 0, 1, 2], k=3, cond=e, discrete_y=True)"
 
 for (name, bench) in [ ("MI", mi_bench),
                        ("CMI", cmi_bench),
-                       ("CMI2", cmi2_bench) ]:
+                       ("CMI2", cmi2_bench),
+                       ("DMI", dmi_bench),
+                       ("DCMI", dcmi_bench) ]:
     for n in [ 100, 400, 1600, 6400 ]:
         res = timeit.repeat(bench, setup, repeat=5, number=1, globals={"N": n})
         print(f"{name:<4}, N={n:<4}: min={np.min(res):<6.3} s, mean={np.mean(res):<6.3} s")

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -14,7 +14,7 @@ import numpy as np
 from os import cpu_count
 import sys
 from ._entropy_estimators import _estimate_single_mi, _estimate_conditional_mi,\
-    _estimate_semidiscrete_mi, _estimate_single_entropy
+    _estimate_semidiscrete_mi, _estimate_conditional_semidiscrete_mi, _estimate_single_entropy
 
 ArrayLike = Union[List[float], List[Tuple[float, ...]], np.ndarray]
 GenArrayLike = TypeVar("GenArrayLike", List[float], List[Tuple[float, ...]], np.ndarray)
@@ -571,6 +571,6 @@ def _lagged_mi(param_tuple: Tuple[np.ndarray, np.ndarray, int, int, int, int,
             raise ValueError(NAN_MSG)
 
         if discrete_y:
-            raise NotImplementedError("Conditional discrete-continuous MI")
+            return _estimate_conditional_semidiscrete_mi(xs, ys, zs, k)
         else:
             return _estimate_conditional_mi(xs, ys, zs, k)

--- a/tests/integration/test_discrete_mi.py
+++ b/tests/integration/test_discrete_mi.py
@@ -1,0 +1,49 @@
+# MIT License - Copyright Petri Laarne and contributors
+# See the LICENSE.md file included in this source code package
+
+"""Reproduce the (Ross 2014) results of discrete-continuous MI.
+
+The setup and reference results are obtained from the supplementary material
+in doi:10.1371/journal.pone.0087357, a set of MATLAB scripts.
+The results here were produced on unmodified scripts and R2019b Update 4.
+"""
+
+from ennemi import estimate_mi
+import numpy as np
+import unittest
+
+class TestDiscreteMi(unittest.TestCase):
+
+    def test_square_wave(self) -> None:
+        # Create 10000 samples from three square waves
+        # The three waves have unequal probabilities
+        rng = np.random.default_rng(2020_07_14)
+        y = rng.choice([0, 1, 2], p=[0.2/1.7, 1.0/1.7, 0.5/1.7], size=10000)
+        x = np.empty(10000)
+        x[y==0] = rng.uniform(0.0, 1.0, np.sum(y==0))
+        x[y==1] = rng.uniform(0.1, 1.2, np.sum(y==1))
+        x[y==2] = rng.uniform(0.2, 1.3, np.sum(y==2))
+
+        # Calculate the (unnormalized) MI
+        actual = estimate_mi(y, x, discrete_y=True)
+
+        # Follows from the definition; this is the output from Ross' script
+        # converted from bits to nats
+        expected = 0.14587 * np.log(2)
+        self.assertAlmostEqual(actual, expected, delta=0.01)
+
+    def test_gaussian(self) -> None:
+        # Create 10000 samples from three Gaussian distributions
+        rng = np.random.default_rng(2020_07_15)
+        y = rng.choice([0, 1, 2], p=[0.2/1.7, 1.0/1.7, 0.5/1.7], size=10000)
+        x = np.empty(10000)
+        x[y==0] = rng.normal(0.4, 0.20, np.sum(y==0))
+        x[y==1] = rng.normal(0.5, 0.30, np.sum(y==1))
+        x[y==2] = rng.normal(0.8, 0.25, np.sum(y==2))
+
+        # Calculate the (unnormalized) MI
+        actual = estimate_mi(y, x, discrete_y=True)
+
+        # As above
+        expected = 0.20524 * np.log(2)
+        self.assertAlmostEqual(actual, expected, delta=0.01)


### PR DESCRIPTION
Closes #32.

- Implement the (Ross 2014) algorithm for unconditional case with discrete y
- Apply the same tweaks to the unconditional case (don't know for sure if documented in literature)
- Add `discrete_y` parameter to `estimate_mi()`

Simply put, the idea is to modify the distance metric so that the different y values are "infinitely" far apart and therefore don't show up in neighbor searches of other y planes. With sufficiently spaced y, the existing algorithm would produce exactly the same results. 

The implementation partitions the space according to y values, using one tree for each y. This reduces the vectorization benefit, but the individual searches are cheaper; by the simple benchmark, this case is faster than the continuous-continuous case.