### PR TITLE
Implement data preprocessing

### DIFF
--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -28,7 +28,6 @@ def _estimate_single_entropy(x: np.ndarray, k: int = 3) -> float:
 
     N, ndim = x.shape
     grid = cKDTree(x, k)
-    distances = np.empty(N)
 
     # Search for the k'th neighbor of each point and store the distance
     distances = grid.query(x, k=[k+1], p=np.inf)[0].flatten()

--- a/tests/integration/test_censored_distribution.py
+++ b/tests/integration/test_censored_distribution.py
@@ -25,12 +25,10 @@ class TestCensoredDistribution(unittest.TestCase):
         expected = self.integrate_mi()
 
         # Sample from the distribution
+        # The automatic preprocessing adds minor noise to the data
         rng = np.random.default_rng(0)
         sample = rng.multivariate_normal(self.mean, self.cov, 4000)
         sample[:,0] = np.maximum(0, sample[:,0])
-
-        # Add low-amplitude noise to the data
-        sample += rng.normal(0.0, 1e-8, size=sample.shape)
 
         # The estimated MI should be very close to the numerical one
         actual = estimate_mi(sample[:,0], sample[:,1])

--- a/tests/integration/test_pandas_workflow.py
+++ b/tests/integration/test_pandas_workflow.py
@@ -14,14 +14,9 @@ class TestPandasWorkflow(unittest.TestCase):
         # Import the Kaisaniemi data set used in documentation
         script_path = os.path.dirname(os.path.abspath(__file__))
         data_path = os.path.join(script_path, "../../docs/kaisaniemi.csv")
-        raw_data = pd.read_csv(data_path, index_col=0, parse_dates=True)
 
-        # Standardize and add low-amplitude noise
-        scaled_data = (raw_data - raw_data.mean()) / raw_data.std()
-        rng = np.random.default_rng(0)
-        scaled_data += rng.normal(0, 1e-10, scaled_data.shape)
-
-        self.data = scaled_data
+        # Data preprocessing is done by ennemi, the distributions are symmetric
+        self.data = pd.read_csv(data_path, index_col=0, parse_dates=True)
 
 
     def test_pairwise_mi(self) -> None:
@@ -47,7 +42,7 @@ class TestPandasWorkflow(unittest.TestCase):
         self.assertAlmostEqual(uncond.loc["Temperature", "DayOfYear"], 0.9, delta=0.03)
 
         # There is no correlation with the conditioning variable
-        self.assertAlmostEqual(cond_doy.loc["Temperature", "DayOfYear"], 0.0, delta=0.02)
+        self.assertLess(cond_doy.loc["Temperature", "DayOfYear"], 0.02)
 
         # The correlation between temperature and wind direction is
         # increased by conditioning on DOY


### PR DESCRIPTION
Closes #54.

- Rescale variables and add low-amplitude noise unless opted out
- Fix one broken test, harden one integration test and fix fallout from changed estimator error
- Simplify some docstrings
- Fix Sonar complaints: refactor `_lagged_mi` and remove unused assignment in entropy algorithm

There is a minor performance hit, but this simplifies user code significantly.