### PR TITLE
Implement quality of life fixes

### DIFF
--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -175,11 +175,10 @@ def _estimate_conditional_entropy(x: np.ndarray, cond: np.ndarray, k: int, multi
     # In the latter case, the joint entropy is calculated for each x variable
     if multidim or x.ndim == 1:
         xs = _mask_and_validate_entropy(np.column_stack((x, cond)), mask, drop_nan, k)
-        joint = _estimate_single_entropy(xs, k)
-        return np.asarray(joint - marginal)
+        return np.asarray(_estimate_single_entropy(xs, k) - marginal)
     else:
         nvar = x.shape[1]
-        joint = np.empty(nvar)
+        joint = np.empty(nvar) # type: np.ndarray
         for i in range(nvar):
             xs = _mask_and_validate_entropy(np.column_stack((x[:,i], cond)), mask, drop_nan, k)
             joint[i] = _estimate_single_entropy(xs, k)

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -603,7 +603,7 @@ def _rescale_data(xs: np.ndarray, ys: np.ndarray, zs: Optional[np.ndarray], disc
         ys += rng.normal(0.0, 1e-10, ys.shape)
     
     if zs is not None:
-        zs = (zs - zs.mean()) / zs.std()
+        zs = (zs - zs.mean(axis=0)) / zs.std(axis=0)
         zs += rng.normal(0.0, 1e-10, zs.shape)
 
     return xs, ys, zs

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -768,7 +768,7 @@ class TestEstimateMi(unittest.TestCase):
         mi1 = estimate_mi(s, w, discrete_y=True, cond=y)
         mi2 = estimate_mi(s, w, discrete_y=True, cond=np.column_stack((y,z)))
 
-        self.assertAlmostEqual(mi2, math.log(2), delta=0.055)
+        self.assertAlmostEqual(mi2, math.log(2), delta=0.06)
         self.assertGreater(mi2, mi1 + 0.1)
         self.assertGreater(mi1, mi0 + 0.1)
 
@@ -1005,6 +1005,17 @@ class TestPairwiseMi(unittest.TestCase):
         mi_scaled = pairwise_mi(data, cond=cond, preprocess=True)
 
         self.assertNotAlmostEqual(mi_unscaled[0,1], 0.0, delta=0.2)
+        self.assertLess(mi_scaled[0,1], 0.03)
+
+    def test_preprocess_two_cond_vars(self) -> None:
+        # As above, but detect if the normalization is done over the whole
+        # cond array, not per-column.
+        data = self.generate_normal(2020_07_27)
+        unif = np.random.default_rng(2020_07_27).uniform(size=len(data)) * 1e6
+        cond = np.column_stack((data[:,0] * 1e-5, unif))
+
+        mi_scaled = pairwise_mi(data, cond=cond, preprocess=True)
+
         self.assertLess(mi_scaled[0,1], 0.03)
 
     def test_normalization(self) -> None:


### PR DESCRIPTION
- Bug fix: `cond` preprocessing was not done per-column; I had this in an earlier version but it was lost in some refactoring
- Bug fix: entropy estimation with both `mask` and `cond` now works
- Fixed #16 by not adding support for masked arrays. Instead, added a `drop_nan` parameter. This has the benefit of working nicely also with pandas and pure Python data types.
- Fixed #30 by adding support for separate lags for each conditioning variable. This is done by passing a 2D array (1D arrays are not promoted for consistency).