### PR TITLE
Add integration tests for unbiasedness

### DIFF
--- a/benchmarks/plot_mi_performance.py
+++ b/benchmarks/plot_mi_performance.py
@@ -1,0 +1,79 @@
+# MIT License - Copyright Petri Laarne and contributors
+# See the LICENSE.md file included in this source code package
+
+"""Plot a visualization of the MI estimation performance.
+
+Requires Matplotlib (not installed by 'pip install ennemi[dev]').
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import timeit
+
+setup = """
+from ennemi import estimate_mi
+import numpy as np
+
+rng = np.random.default_rng(0)
+x = rng.normal(size=n)
+y = rng.normal(size=n)
+z = rng.normal(size=(n, 2))
+"""
+
+all_ks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+          15, 20, 25, 30, 35, 40, 45, 50]
+all_ns = np.linspace(200, 25000, 20, dtype=np.int32)
+
+names = ["2D condition", "1D condition", "Unconditional"]
+benches = [
+    "estimate_mi(y,x,k=k,cond=z)",
+    "estimate_mi(y,x,k=k,cond=z[:,0])",
+    "estimate_mi(y,x,k=k)",
+]
+
+# The N plot
+print("Using different values of n...")
+
+results_n = np.empty((len(all_ns), len(benches)))
+for (i, n) in enumerate(all_ns):
+    for (j, test) in enumerate(benches):
+        print(f"n={n:>4}, {names[j]}")
+        times = timeit.repeat(test, setup,
+                              repeat=10, number=1,
+                              globals={"k":5, "n":n})
+        best = np.min(times)
+        results_n[i,j] = best
+
+# The k plot
+print("Using different values of k...")
+
+results_k = np.empty((len(all_ks), len(benches)))
+for (i, k) in enumerate(all_ks):
+    for (j, test) in enumerate(benches):
+        print(f"k={k:>2}, {names[j]}")
+        times = timeit.repeat(test, setup,
+                              repeat=10, number=1,
+                              globals={"k":k, "n":10000})
+        best = np.min(times)
+        results_k[i,j] = best
+
+# Draw the plots
+fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8,4.5), constrained_layout=True, sharey=True)
+
+for (i, name) in enumerate(names):
+    ax1.plot(all_ns, results_n[:,i], label=name, marker=".")
+    ax2.plot(all_ks, results_k[:,i], label=name, marker=".")
+
+ax1.set_xlabel("$n$ (fixed $k = 5$)")
+ax1.set_ylabel("Execution time (s)")
+ax1.set_xticks([0, 5000, 10000, 15000, 20000, 25000])
+ax1.set_xticks([0, 2500, 7500, 12500, 17500, 22500], minor=True)
+ax1.set_yticks([0.25, 0.75, 1.25, 1.75, 2.25], minor=True)
+ax1.grid()
+ax1.legend()
+
+ax2.set_xlabel("$k$ (fixed $n = 10000$)")
+ax2.grid()
+ax2.legend()
+
+plt.savefig("mi_perf.pdf", transparent=True)

--- a/tests/integration/test_unbiasedness.py
+++ b/tests/integration/test_unbiasedness.py
@@ -1,0 +1,84 @@
+# MIT License - Copyright Petri Laarne and contributors
+# See the LICENSE.md file included in this source code package
+
+"""Verify that the MI and entropy estimates are unbiased."""
+
+from ennemi import estimate_entropy, estimate_mi
+from math import log, pi, e
+import numpy as np
+import unittest
+
+class TestUnbiasedness(unittest.TestCase):
+    
+    def test_unconditional_mi_bias(self) -> None:
+        # A highly correlated distribution
+        rng = np.random.default_rng(0)
+        cov = [[1, 0.8], [0.8, 1]]
+        data = rng.multivariate_normal([0, 0], cov, size=20_000)
+        
+        mi_3 = estimate_mi(data[:,0], data[:,1], k=3)
+        mi_100 = estimate_mi(data[:,0], data[:,1], k=100)
+
+        # Large k will have some bias, small k should not
+        expected = -0.5 * log(1 - 0.8**2)
+        self.assertAlmostEqual(mi_3, expected, delta=0.005)
+        self.assertGreater(abs(mi_100 - expected), abs(mi_3 - expected) + 0.005)
+
+    def test_unconditional_mi_independence(self) -> None:
+        rng = np.random.default_rng(0)
+        cov = [[1, 0], [0, 1]]
+        data = rng.multivariate_normal([0, 0], cov, size=20_000)
+        
+        mi_3 = estimate_mi(data[:,0], data[:,1], k=3)
+        mi_100 = estimate_mi(data[:,0], data[:,1], k=100)
+
+        # Large k should be better for independence testing
+        self.assertAlmostEqual(mi_100, 0.0, delta=0.004)
+        self.assertGreater(mi_3 - mi_100, 0.002)
+
+
+    def test_conditional_mi_independence(self) -> None:
+        # X and X+Y are independent given Y
+        rng = np.random.default_rng(0)
+        x = rng.normal(0.0, 1.0, size=20_000)
+        y = rng.normal(0.0, 1.0, size=20_000)
+        
+        mi_3 = estimate_mi(x, x+y, cond=x, k=3)
+        mi_100 = estimate_mi(x, x+y, cond=x, k=100)
+
+        # Large k should be better for independence testing here as well
+        self.assertAlmostEqual(mi_100, 0.0, delta=0.005)
+        self.assertGreater(abs(mi_3 - mi_100), 0.05)
+
+
+    def test_entropy_bias(self) -> None:
+        rng = np.random.default_rng(0)
+        x = rng.normal(size=20_000)
+
+        h_1 = estimate_entropy(x, k=1)
+        h_100 = estimate_entropy(x, k=100)
+
+        # Small k has positive bias, large k has negative bias
+        expected = 0.5*log(2*pi*e)
+        self.assertGreater(h_1, expected + 0.005)
+        self.assertLess(h_100, expected - 0.005)
+
+        # Still, both are reasonably close, and large k is closer
+        self.assertAlmostEqual(h_1, expected, delta=0.04)
+        self.assertAlmostEqual(h_100, expected, delta=0.01)
+
+
+    def test_conditional_entropy_bias(self) -> None:
+        # This is especially interesting as errors might not cancel out in the chain rule
+        # Use the 3D Gaussian distribution seen in the driver test
+        rng = np.random.default_rng(0)
+        cov = np.asarray([[1, 0.6, 0.3], [0.6, 2, 0.1], [0.3, 0.1, 1]])
+        data = rng.multivariate_normal([0, 0, 0], cov, size=20_000)
+
+        h_5 = estimate_entropy(data[:,:2], cond=data[:,2], multidim=True, k=5)
+        h_50 = estimate_entropy(data[:,:2], cond=data[:,2], multidim=True, k=50)
+
+        # Again, large k appears to have more negative bias
+        expected = 0.5 * (log(np.linalg.det(2 * pi * e * cov)) - log(2 * pi * e))
+        self.assertAlmostEqual(h_5, expected, delta=0.005)
+        self.assertAlmostEqual(h_50, expected, delta=0.03)


### PR DESCRIPTION
- Closes #44 by adding integration tests for some estimation methods.
- Adds a performance visualization script (written for a manuscript).