### PR TITLE
Add package build to CI script

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Run type checker
         run: |
           python -m mypy ennemi/ tests/unit tests/integration
+
+      - name: Try building the package
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        run: |
+          pip install setuptools wheel
+          python setup.py sdist bdist_wheel
       
       - name: Run Sonar code analysis
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -512,9 +512,8 @@ def _pairwise_mi(data: np.ndarray, k: int, cond: Optional[np.ndarray], preproces
 def _get_mi_time_estimate(n: int, cond: Optional[np.ndarray], k: int) -> float:
     if cond is None:
         n_cond = 0
-    elif cond.ndim == 1:
-        n_cond = 1
     else:
+        # cond is guaranteed to be two-dimensional
         n_cond = cond.shape[1]
 
     # These are determined pretty experimentally on a laptop computer


### PR DESCRIPTION
- Try building the package on the Ubuntu+3.8 combination. Before this, any errors in the `setup.py` script would go unnoticed until PyPI publish time.
- Remove one unreachable line in `driver.py` that was spoiling our 100% coverage.