### PR TITLE
Add Python 3.9 to CI script

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
         # Save a bit of resources by running only some combinations:
-        # Windows 3.6, macOS 3.7 and Ubuntu 3.8
+        # Windows 3.6 and 3.9; macOS 3.7; Ubuntu 3.8 and 3.9
         exclude:
           - os: windows-latest
             python-version: 3.7
@@ -32,6 +32,8 @@ jobs:
             python-version: 3.6
           - os: macos-latest
             python-version: 3.8
+          - os: macos-latest
+            python-version: 3.9
           - os: ubuntu-latest
             python-version: 3.6
           - os: ubuntu-latest
@@ -51,7 +53,7 @@ jobs:
           pip install -e .[dev]
       
       - name: Run unit tests (with coverage)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
         # We have to rename the path in coverage.xml since Sonar is run in Docker
         # and has a different view of the file system
         run: |
@@ -60,7 +62,7 @@ jobs:
           sed 's/\/home\/runner\/work\/ennemi\/ennemi/\/github\/workspace/g' coverage.xml > coverage-mod.xml
       
       - name: Run unit tests (no coverage)
-        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.8'
+        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.9'
         run: |
           python -m pytest tests/unit/ --junit-xml=test-results.xml
 
@@ -69,13 +71,13 @@ jobs:
           python -m mypy ennemi/ tests/unit tests/integration tests/pandas
 
       - name: Try building the package
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
         run: |
           pip install setuptools wheel
           python setup.py sdist bdist_wheel
       
       - name: Run Sonar code analysis
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ The package uses the nearest neighbor methods decscribed in:
   PLoS ONE 9.
   [doi:10.1371/journal.pone.0087357](https://dx.doi.org/10.1371/journal.pone.0087357).
 
-The latest source code on GitHub might be more unstable than the released version on PyPI.
+The latest source code on GitHub might be less stable than the released version on PyPI.
 You can see the roadmap of planned additions on the
 [Milestones page](https://github.com/polsys/ennemi/milestones).
-LinSee also the [support statement](docs/support.md).
+See also the [support statement](docs/support.md).
 
 
 ## Getting started
@@ -83,7 +83,7 @@ To do so, use the DOI given on the [Releases](https://github.com/polsys/ennemi/r
 In the future, a journal article may become the canonical reference for this package.
 You should still also cite the package version you have used.
 
-This package is maintained by Petri Laarne at
+This package is maintained by Petri Laarne, and was initially developed at
 [Institute for Atmospheric and Earth System Research (INAR)](https://www.helsinki.fi/en/inar-institute-for-atmospheric-and-earth-system-research),
 University of Helsinki.
 Please feel free to contact me at `firstname.lastname@helsinki.fi`

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Scientific/Engineering :: Mathematics",


### PR DESCRIPTION
Closes #49. Run tests with 3.9 and mention support in `setup.py`.

To do: clean up the CI script, but I don't feel like wrestling with Actions syntax right now. Deferring to the next time... :shipit: