### PR TITLE
Adapt to LaTeX processor change on GitHub Pages

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -11,25 +11,8 @@
         MathJax = {
           tex: {
               inlineMath: [['$', '$']],
+              displayMath: [['\\(', '\\)']],
               processEscapes: true
-          },
-          options: {
-            // The Markdown converter produces MathJax v2 style display math...
-            // See http://docs.mathjax.org/en/latest/upgrading/v2.html
-            renderActions: {
-              findScript: [10, function (doc) {
-                for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
-                  // The parser only converts $$ blocks
-                  const display = true;
-                  const math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
-                  const text = document.createTextNode('');
-                  node.parentNode.replaceChild(text, node);
-                  math.start = {node: text, delim: '', n: 0};
-                  math.end = {node: text, delim: '', n: 0};
-                  doc.math.push(math);
-                }
-              }, '']
-            }
           }
         };
     </script>


### PR DESCRIPTION
This should fix broken display math on the docs. Or maybe not. It's hard to say because GitHub pages cannot be previewed...