### PR TITLE
Update typing for NumPy 1.20

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,6 +67,8 @@ jobs:
           python -m pytest tests/unit/ --junit-xml=test-results.xml
 
       - name: Run type checker
+        # NumPy 1.20 with type annotations does not support Python 3.6
+        if: matrix.python-version != '3.6'
         run: |
           python -m mypy ennemi/ tests/unit tests/integration tests/pandas
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -71,12 +71,6 @@ Lower versions of `ennemi` will remain available for users of those.
 
 In the long term, we aim to follow the
 [NumPy deprecation policy](https://numpy.org/neps/nep-0029-deprecation_policy.html).
-However, there are some deviations:
-
-- `ennemi 1.0.0` requires at least NumPy 1.17.
-  This satisfies the "last three minor versions" rule, but not the
-  "all versions released in prior 24 months" rule.
-  Support for NumPy 1.17 will be kept long enough to satisfy both criteria.
-- `ennemi 1.0.0` supports Python 3.6, even though it would not be necessary.
-  There are still sufficiently many users on 3.6 to warrant the support.
-  The support will be dropped in a future minor release.
+However, `ennemi 1.0.0` supports Python 3.6, even though it would not be necessary.
+There are still sufficiently many users on 3.6 to warrant the support.
+The support will be dropped in a future minor release.

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -9,6 +9,7 @@ Use the `estimate_mi` method in the main ennemi module instead.
 
 import numpy as np
 from scipy.spatial import cKDTree
+from typing import Union
 from warnings import warn
 
 
@@ -224,7 +225,7 @@ def _estimate_conditional_semidiscrete_mi(x: np.ndarray, y: np.ndarray, cond: np
 # Digamma
 #
 
-def _psi(x: np.ndarray) -> np.ndarray:
+def _psi(x: Union[int, np.ndarray]) -> np.ndarray:
     """A replacement for scipy.special.psi, for non-negative integers only.
     
     This is slightly faster than the SciPy version (not that it's a bottleneck),
@@ -236,7 +237,7 @@ def _psi(x: np.ndarray) -> np.ndarray:
     # psi(0) = inf for SciPy compatibility
     # The shape of result does not matter as inf will propagate in mean()
     if np.any(x == 0):
-        return np.inf
+        return np.asarray(np.inf)
 
     # Use the SciPy value for psi(1), because the expansion is not good enough
     mask = (x != 1)

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,17 +13,16 @@ disallow_any_generics = True
 disallow_subclassing_any = True
 no_implicit_optional = True
 
-# We still need to disable some checks because NumPy is not annotated
-disallow_any_expr = False
-warn_return_any = False
+# BUG: assertAlmostEqual(ndarray, float, float) does not work
+# because mypy does not understand the implicit conversion.
+# I cannot find any other solution than to disable the error code altogether.
+# This is very suboptimal.
+disable_error_code = call-overload
 
-
-# Skip imports that do not have type information
-[mypy-numpy.*]
-ignore_missing_imports = True
-
+# NumPy is annotated but pandas and SciPy are not
 [mypy-scipy.*]
 ignore_missing_imports = True
 
 [mypy-pandas.*]
 ignore_missing_imports = True
+

--- a/tests/pandas/test_pandas_workflow.py
+++ b/tests/pandas/test_pandas_workflow.py
@@ -24,9 +24,9 @@ class TestPandasWorkflow(unittest.TestCase):
         columns = ["Temperature", "WindDir", "DayOfYear"]
         afternoon_mask = (self.data.index.hour == 13)
 
-        uncond = pairwise_mi(self.data[columns], mask=afternoon_mask, normalize=True)
+        uncond = pairwise_mi(self.data[columns], mask=afternoon_mask, normalize=True) # type: pd.DataFrame
         cond_doy = pairwise_mi(self.data[columns], mask=afternoon_mask, normalize=True,
-            cond=self.data["DayOfYear"])
+            cond=self.data["DayOfYear"]) # type: pd.DataFrame
 
         # The result is a 3x3 data frame
         self.assertEqual(uncond.shape, (3,3))
@@ -55,7 +55,7 @@ class TestPandasWorkflow(unittest.TestCase):
         afternoon_mask = (self.data.index.hour == 13)
         result = estimate_mi(self.data["Temperature"], self.data["Temperature"],
             lag=[0, -24, -10*24], cond=self.data["DayOfYear"], mask=afternoon_mask,
-            normalize=True)
+            normalize=True) # type: pd.DataFrame
 
         # The result is a 3x1 data frame
         self.assertEqual(result.shape, (3,1))

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -9,7 +9,7 @@ import numpy as np
 import os.path
 import pandas as pd
 import random
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 import unittest
 from ennemi import estimate_entropy, estimate_mi, normalize_mi, pairwise_mi
 
@@ -122,7 +122,7 @@ class TestEstimateEntropy(unittest.TestCase):
             "Exp": rng.exponential(1/2.0, size=500)
         })
 
-        marginal = estimate_entropy(data)
+        marginal = estimate_entropy(data) # type: pd.DataFrame
         multidim = estimate_entropy(data, multidim=True)
 
         # multidim=False results in a DataFrame
@@ -141,7 +141,7 @@ class TestEstimateEntropy(unittest.TestCase):
         rng = np.random.default_rng(2)
         data = pd.Series(rng.normal(0.0, 1.0, size=500), name="N")
 
-        result = estimate_entropy(data)
+        result = estimate_entropy(data) # type: pd.DataFrame
 
         self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(result.shape, (1,1))
@@ -404,7 +404,7 @@ class TestEstimateMi(unittest.TestCase):
         y = [5, 6, 7, 8]
 
         with self.assertRaises(TypeError):
-            estimate_mi(y, x, lag=1.2)
+            estimate_mi(y, x, lag=1.2) # type: ignore
 
     def test_x_and_cond_different_length(self) -> None:
         x = np.zeros(10)
@@ -441,7 +441,7 @@ class TestEstimateMi(unittest.TestCase):
     def test_mask_with_wrong_dimension(self) -> None:
         x = np.zeros(10)
         y = np.zeros(10)
-        mask = np.zeros((10, 2), dtype=np.bool)
+        mask = np.zeros((10, 2), dtype=bool)
 
         with self.assertRaises(ValueError) as cm:
             estimate_mi(y, x, mask=mask)
@@ -596,7 +596,7 @@ class TestEstimateMi(unittest.TestCase):
         data_path = os.path.join(script_path, "example_data.csv")
         data = pd.read_csv(data_path)
 
-        actual = estimate_mi(data["y"], data[["x1", "x2", "x3"]], lag=[0, 1, 3], k=5)
+        actual = estimate_mi(data["y"], data[["x1", "x2", "x3"]], lag=[0, 1, 3], k=5) # type: pd.DataFrame
 
         # The returned object is a Pandas data frame, with row and column names!
         self.assertIsInstance(actual, pd.DataFrame)
@@ -630,7 +630,7 @@ class TestEstimateMi(unittest.TestCase):
                           index=range(2000, 3000))
 
         expected = -0.5 * math.log(1 - 0.8**2)
-        masked = estimate_mi(df["y"], df["x"], mask=df["mask"])
+        masked = estimate_mi(df["y"], df["x"], mask=df["mask"]) # type: pd.DataFrame
         self.assertAlmostEqual(masked.loc[0,"x"], expected, delta=0.03)
 
     def test_mask_without_lag(self) -> None:
@@ -747,7 +747,7 @@ class TestEstimateMi(unittest.TestCase):
         data = pd.read_csv(data_path)
 
         actual = estimate_mi(data["y"], data["x1"], lag=-1, k=5,
-                             cond=data["x2"], cond_lag=0)
+                             cond=data["x2"], cond_lag=0) # type: pd.DataFrame
 
         self.assertIsInstance(actual, pd.DataFrame)
         self.assertEqual(actual.shape, (1, 1))
@@ -815,11 +815,10 @@ class TestEstimateMi(unittest.TestCase):
                 y = np.zeros(100)
                 if ynan: y[25] = np.nan
 
+                cond = None # type: Optional[np.ndarray]
                 if condnan is not None:
                     cond = np.zeros(100)
                     if condnan: cond[37] = np.nan
-                else:
-                    cond = None
 
                 with self.assertRaises(ValueError) as cm:
                     # Pass preprocess=False to avoid warnings with the zero data
@@ -986,7 +985,7 @@ class TestNormalizeMi(unittest.TestCase):
         mi = [-1, 0, 1]
         cor = normalize_mi(mi)
 
-        self.assertEqual(cor.shape, (3,))
+        self.assertEqual(cor.shape, (3,)) # type: ignore
         self.assertAlmostEqual(cor[0], -1.0, delta=0.001)
         self.assertAlmostEqual(cor[1], 0.0, delta=0.001)
         self.assertAlmostEqual(cor[2], 0.93, delta=0.03)
@@ -995,7 +994,7 @@ class TestNormalizeMi(unittest.TestCase):
         mi = np.asarray([[0.1, 0.5], [0, -1]])
         mi = pd.DataFrame(mi, columns=["A", "B"], index=[14, 52])
 
-        cor = normalize_mi(mi)
+        cor = normalize_mi(mi) # type: pd.DataFrame
         self.assertAlmostEqual(cor.loc[14,"A"], 0.4, delta=0.05)
         self.assertAlmostEqual(cor.loc[14,"B"], 0.8, delta=0.05)
         self.assertAlmostEqual(cor.loc[52,"A"], 0.0, delta=0.001)
@@ -1064,7 +1063,7 @@ class TestPairwiseMi(unittest.TestCase):
         expected = -0.5 * math.log(1 - 0.6**2)
 
         data = pd.DataFrame({"X": normal_data[:,0], "Y": normal_data[:,1], "Z": unif_data})
-        result = pairwise_mi(data)
+        result = pairwise_mi(data) # type: pd.DataFrame
 
         self.assertEqual(result.shape, (3,3))
         self.assertIsInstance(result, pd.DataFrame)


### PR DESCRIPTION
Part of #48. Enable type annotations for NumPy now that they exist. To support NumPy 1.20, replace `np.bool` with `bool` etc.

Had to disable one error message because of numerous false positives. This is an issue since there seems to be no way to suppress only this specific method.