### PR TITLE
Start 1.1 release cycle

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,24 +20,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9 ]
         # Save a bit of resources by running only some combinations:
-        # Windows 3.6 and 3.9; macOS 3.7; Ubuntu 3.8 and 3.9
+        # Windows 3.7 and 3.9; macOS 3.8; Ubuntu 3.7 and 3.9
         exclude:
           - os: windows-latest
+            python-version: 3.8
+          - os: macos-latest
             python-version: 3.7
-          - os: windows-latest
-            python-version: 3.8
-          - os: macos-latest
-            python-version: 3.6
-          - os: macos-latest
-            python-version: 3.8
           - os: macos-latest
             python-version: 3.9
           - os: ubuntu-latest
-            python-version: 3.6
-          - os: ubuntu-latest
-            python-version: 3.7
+            python-version: 3.8
 
     steps:
       - name: Check out code

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.7
 
       - name: Install dependencies with custom versions
         # Note: This must be kept in sync with the minimum versions in setup.py

--- a/README.md
+++ b/README.md
@@ -81,8 +81,19 @@ always resolves to the latest version of `ennemi`.
 For reproducibility, you should cite the exact version of the package you have used.
 To do so, use the DOI given on the [Releases](https://github.com/polsys/ennemi/releases) page or on Zenodo.
 
-In the future, a journal article may become the canonical reference for this package.
-You should still also cite the package version you have used.
+If you want to cite an article
+(although you should still mention the version number you used), the reference is:
+```
+@article{ennemi,
+  title = {ennemi: Non-linear correlation detection with mutual information},
+  journal = {SoftwareX},
+  volume = {14},
+  pages = {100686},
+  year = {2021},
+  doi = {https://doi.org/10.1016/j.softx.2021.100686},
+  author = {Petri Laarne and Martha A. Zaidan and Tuomo Nieminen}
+}
+```
 
 This package is maintained by Petri Laarne, and was initially developed at
 [Institute for Atmospheric and Earth System Research (INAR)](https://www.helsinki.fi/en/inar-institute-for-atmospheric-and-earth-system-research),

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can also follow the development by clicking `Watch releases` on the GitHub p
 
 ## Getting started
 
-This package requires Python 3.6 or higher,
+This package requires Python 3.7 or higher,
 and it is tested to work on the latest versions of Ubuntu, macOS and Windows.
 The only hard dependencies are reasonably recent versions of NumPy and SciPy;
 Pandas is strongly suggested for more enjoyable data analysis.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,12 @@ with no theoretical background required.
 University of Helsinki.
 The package is published under the MIT License.
 
+This software is also described in the SoftwareX article
+[doi:10.1016/j.softx.2021.100686](https://dx.doi.org/10.1016/j.softx.2021.100686).
+If you use this software in scientific work, please mention also the exact version number for reproducibility.
+Archived versions of the source code are available on Zenodo
+([doi:10.5281/zenodo.3834018](https://doi.org/10.5281/zenodo.3834018)).
+
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ with no theoretical background required.
   - Integrated with `pandas` data frames (optional)
   - Optimized and automatically parallelized estimation
 
-`ennemi` is currently developed by Petri Laarne ([@polsys](https://github.com/polsys)) at
+`ennemi` is has been developed by Petri Laarne ([@polsys](https://github.com/polsys)) at
 [Institute for Atmospheric and Earth System Research (INAR)](https://www.helsinki.fi/en/inar-institute-for-atmospheric-and-earth-system-research),
 University of Helsinki.
 The package is published under the MIT License.

--- a/docs/support.md
+++ b/docs/support.md
@@ -52,10 +52,10 @@ This means that the version number is always of the format `X.Y.Z`.
 
 Some examples (not necessary real!):
 
-- `1.0.0 -> 1.0.1` would only contain bug fixes.
-- `1.0.1 -> 1.1.0` would contain new features and bug fixes.
-  It might also drop support for older Python or NumPy versions.
-  Users of older Python versions would remain on `1.0.1`.
+- `1.0.0 -> 1.0.1` (if it existed) would only contain bug fixes.
+- `1.0.1 -> 1.1.0` contains new features and bug fixes.
+  It also drops support for Python&nbsp;3.6.
+  Version `1.0.x` remains available for those using Python&nbsp;3.6.
 - `1.1.0 -> 2.0.0` would break some of your code.
   It might remove features, and therefore you should be careful when upgrading.
 
@@ -71,6 +71,3 @@ Lower versions of `ennemi` will remain available for users of those.
 
 In the long term, we aim to follow the
 [NumPy deprecation policy](https://numpy.org/neps/nep-0029-deprecation_policy.html).
-However, `ennemi 1.0.0` supports Python 3.6, even though it would not be necessary.
-There are still sufficiently many users on 3.6 to warrant the support.
-The support will be dropped in a future minor release.

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -6,6 +6,7 @@
 Do not import this module directly, but rather import the main ennemi module.
 """
 
+from __future__ import annotations
 import concurrent.futures
 from typing import Callable, Iterable, Optional, Sequence, Tuple, TypeVar, Union
 import itertools

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -7,6 +7,7 @@ Do not import this module directly.
 Use the `estimate_mi` method in the main ennemi module instead.
 """
 
+from __future__ import annotations
 import numpy as np
 from scipy.spatial import cKDTree
 from typing import Union

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -46,7 +45,7 @@ setup(
 
     packages = [ "ennemi" ],
     package_data = { "ennemi": ["py.typed"] },
-    python_requires = "~=3.6",
+    python_requires = "~=3.7",
     # At least pandas requires numpy 1.17.3+ (security fixes), we should too
     install_requires = [ "numpy>=1.17.5", "numpy<2.0", "scipy~=1.4" ],
     extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(description_file, encoding="utf-8") as f:
 
 setup(
     name = "ennemi",
-    version = "1.0.0",
+    version = "1.1.0",
     description = "Non-linear correlation detection with mutual information",
     long_description = long_description,
     long_description_content_type = "text/markdown",

--- a/tests/integration/test_censored_distribution.py
+++ b/tests/integration/test_censored_distribution.py
@@ -7,6 +7,7 @@ There is no analytical expression for the MI, and the algorithm in ennemi
 expects a continuous distribution. Nevertheless, ennemi seems to work fine.
 """
 
+from __future__ import annotations
 from ennemi import estimate_mi
 from scipy.integrate import quad, dblquad
 from scipy.stats import norm, multivariate_normal as mvnorm

--- a/tests/integration/test_discrete_mi.py
+++ b/tests/integration/test_discrete_mi.py
@@ -8,6 +8,7 @@ in doi:10.1371/journal.pone.0087357, a set of MATLAB scripts.
 The results here were produced on unmodified scripts and R2019b Update 4.
 """
 
+from __future__ import annotations
 from ennemi import estimate_mi
 import numpy as np
 import unittest

--- a/tests/integration/test_entropy_identities.py
+++ b/tests/integration/test_entropy_identities.py
@@ -3,6 +3,7 @@
 
 """Mathematical identities for entropy and mutual information."""
 
+from __future__ import annotations
 from ennemi import estimate_entropy, estimate_mi
 import numpy as np
 import unittest

--- a/tests/integration/test_lorenz.py
+++ b/tests/integration/test_lorenz.py
@@ -11,6 +11,7 @@ This test exercises especially the conditional MI code path, as the condition
 is 7-dimensional. It also passes a two-dimensional cond_lag parameter.
 """
 
+from __future__ import annotations
 from ennemi import estimate_mi
 import numpy as np
 import unittest

--- a/tests/integration/test_mixture_distribution.py
+++ b/tests/integration/test_mixture_distribution.py
@@ -3,6 +3,7 @@
 
 """A mixture distribution that has no analytical expression for MI."""
 
+from __future__ import annotations
 from ennemi import estimate_mi
 from scipy.integrate import dblquad
 from scipy.stats import norm, multivariate_normal as mvnorm

--- a/tests/integration/test_unbiasedness.py
+++ b/tests/integration/test_unbiasedness.py
@@ -3,6 +3,7 @@
 
 """Verify that the MI and entropy estimates are unbiased."""
 
+from __future__ import annotations
 from ennemi import estimate_entropy, estimate_mi
 from math import log, pi, e
 import numpy as np

--- a/tests/pandas/test_pandas_workflow.py
+++ b/tests/pandas/test_pandas_workflow.py
@@ -3,6 +3,7 @@
 
 """A simplified version of the case study in the documentation."""
 
+from __future__ import annotations
 from ennemi import estimate_mi, pairwise_mi
 import numpy as np
 import pandas as pd

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -3,6 +3,7 @@
 
 """Tests for ennemi.estimate_mi()."""
 
+from __future__ import annotations
 from itertools import product
 import math
 import numpy as np

--- a/tests/unit/test_entropy_estimators.py
+++ b/tests/unit/test_entropy_estimators.py
@@ -3,6 +3,7 @@
 
 """Tests for ennemi._estimate_single_mi() and friends."""
 
+from __future__ import annotations
 import math
 from math import log
 import numpy as np


### PR DESCRIPTION
Part of #83.

- Drop Python 3.6 support and CI pipelines. Fixes #64.
- Reference the SoftwareX article in README and docs