### PR TITLE
Update annotations for latest NumPy/mypy

### DIFF
--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -9,12 +9,15 @@ Use the `estimate_mi` method in the main ennemi module instead.
 
 from __future__ import annotations
 import numpy as np
+import numpy.typing as npt
 from scipy.spatial import cKDTree
 from typing import Union
 from warnings import warn
 
+FloatArray = npt.NDArray[np.float64]
 
-def _estimate_single_entropy(x: np.ndarray, k: int = 3) -> float:
+
+def _estimate_single_entropy(x: FloatArray, k: int = 3) -> float:
     """Estimate the differential entropy of a n-dimensional random variable.
 
     `x` must be a 2D array with columns denoting the variable dimensions.
@@ -38,7 +41,7 @@ def _estimate_single_entropy(x: np.ndarray, k: int = 3) -> float:
     return _psi(N) - _psi(k) + ndim * (np.mean(np.log(distances)) + np.log(2))
 
 
-def _estimate_single_mi(x: np.ndarray, y: np.ndarray, k: int = 3) -> float:
+def _estimate_single_mi(x: FloatArray, y: FloatArray, k: int = 3) -> float:
     """Estimate the mutual information between two continuous variables.
 
     Returns the estimated mutual information (in nats).
@@ -85,7 +88,7 @@ def _estimate_single_mi(x: np.ndarray, y: np.ndarray, k: int = 3) -> float:
     return _psi(N) + _psi(k) - np.mean(_psi(nx) + _psi(ny))
 
 
-def _estimate_conditional_mi(x: np.ndarray, y: np.ndarray, cond: np.ndarray, 
+def _estimate_conditional_mi(x: FloatArray, y: FloatArray, cond: FloatArray, 
         k: int = 3) -> float:
     """Estimate conditional mutual information between two continuous variables.
 
@@ -128,7 +131,7 @@ def _estimate_conditional_mi(x: np.ndarray, y: np.ndarray, cond: np.ndarray,
     return _psi(k) - np.mean(_psi(nxz) + _psi(nyz) - _psi(nz))
 
 
-def _estimate_semidiscrete_mi(x: np.ndarray, y: np.ndarray, k: int = 3) -> float:
+def _estimate_semidiscrete_mi(x: FloatArray, y: FloatArray, k: int = 3) -> float:
     """Estimate unconditional MI between discrete y and continuous x.
     
     The calculation is based on Ross (2014): Mutual Information between
@@ -172,7 +175,7 @@ def _estimate_semidiscrete_mi(x: np.ndarray, y: np.ndarray, k: int = 3) -> float
     return _psi(N) + _psi(k) - np.mean(_psi(n_full)) - weighted_y_counts_mean
 
 
-def _estimate_conditional_semidiscrete_mi(x: np.ndarray, y: np.ndarray, cond: np.ndarray, 
+def _estimate_conditional_semidiscrete_mi(x: FloatArray, y: FloatArray, cond: FloatArray, 
         k: int = 3) -> float:
     """Estimate conditional MI between discrete y and continuous x and cond.
 
@@ -226,7 +229,7 @@ def _estimate_conditional_semidiscrete_mi(x: np.ndarray, y: np.ndarray, cond: np
 # Digamma
 #
 
-def _psi(x: Union[int, np.ndarray]) -> np.ndarray:
+def _psi(x: Union[int, FloatArray]) -> FloatArray:
     """A replacement for scipy.special.psi, for non-negative integers only.
     
     This is slightly faster than the SciPy version (not that it's a bottleneck),

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,12 +6,14 @@ warn_unreachable = True
 
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
-disallow_untyped_calls = True
 disallow_any_decorated = True
 disallow_any_explicit = True
 disallow_any_generics = True
 disallow_subclassing_any = True
 no_implicit_optional = True
+
+# Not all of NumPy is annotated yet
+disallow_untyped_calls = False
 
 # BUG: assertAlmostEqual(ndarray, float, float) does not work
 # because mypy does not understand the implicit conversion.
@@ -25,4 +27,3 @@ ignore_missing_imports = True
 
 [mypy-pandas.*]
 ignore_missing_imports = True
-

--- a/tests/integration/test_lorenz.py
+++ b/tests/integration/test_lorenz.py
@@ -14,11 +14,12 @@ is 7-dimensional. It also passes a two-dimensional cond_lag parameter.
 from __future__ import annotations
 from ennemi import estimate_mi
 import numpy as np
+import numpy.typing as npt
 import unittest
 
 class TestLorenz(unittest.TestCase):
 
-    def simulate(self) -> np.ndarray:
+    def simulate(self) -> npt.NDArray[np.float64]:
         # Simulate the three Lorenz systems with 100x time resolution
         # Unlike Frenzel & Pompe, we use Euler's method for simplicity
         TIME_FACTOR = 100
@@ -59,7 +60,7 @@ class TestLorenz(unittest.TestCase):
         return y[BURNIN::TIME_FACTOR]
 
 
-    def verify_unconditional(self, data: np.ndarray) -> None:
+    def verify_unconditional(self, data: npt.NDArray[np.float64]) -> None:
         # Check the top row of Frenzel & Pompe, Figure 3
         lags = np.arange(-30, 30+1)
 
@@ -84,7 +85,7 @@ class TestLorenz(unittest.TestCase):
         self.assertAlmostEqual(mi[argmax], 0.6, delta=0.03)
 
 
-    def verify_conditional(self, data: np.ndarray) -> None:
+    def verify_conditional(self, data: npt.NDArray[np.float64]) -> None:
         # Check the bottom row of Figure 3
         # The conditioning variable is seven copies of the remaining variable
         # lagged symmetrically around the MI peak, as specified in the article.

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from itertools import product
 import math
 import numpy as np
+import numpy.typing as npt
 import os.path
 import pandas as pd
 import random
@@ -405,7 +406,7 @@ class TestEstimateMi(unittest.TestCase):
         y = [5, 6, 7, 8]
 
         with self.assertRaises(TypeError):
-            estimate_mi(y, x, lag=1.2) # type: ignore
+            estimate_mi(y, x, lag=1.2)
 
     def test_x_and_cond_different_length(self) -> None:
         x = np.zeros(10)
@@ -770,7 +771,7 @@ class TestEstimateMi(unittest.TestCase):
         self.assertAlmostEqual(single_cond.item(), 0.33, delta=0.03)
         self.assertGreater(many_cond.item(), 1.0)
 
-    def _create_4d_data(self) -> Tuple[np.ndarray, float]:
+    def _create_4d_data(self) -> Tuple[npt.NDArray[np.float64], float]:
         # The same dataset as in test_four_gaussians algorithm test
         rng = np.random.default_rng(2020_07_29)
         cov = np.array([[1, 0, 2, 1],
@@ -816,7 +817,7 @@ class TestEstimateMi(unittest.TestCase):
                 y = np.zeros(100)
                 if ynan: y[25] = np.nan
 
-                cond = None # type: Optional[np.ndarray]
+                cond = None # type: Optional[npt.NDArray[np.float64]]
                 if condnan is not None:
                     cond = np.zeros(100)
                     if condnan: cond[37] = np.nan
@@ -1004,7 +1005,7 @@ class TestNormalizeMi(unittest.TestCase):
 
 class TestPairwiseMi(unittest.TestCase):
 
-    def generate_normal(self, seed: int) -> np.ndarray:
+    def generate_normal(self, seed: int) -> npt.NDArray[np.float64]:
         rng = np.random.default_rng(seed)
         cov = np.asarray([[1, 0.6], [0.6, 1]])
         return rng.multivariate_normal([0, 0], cov, 1000)


### PR DESCRIPTION
The combination of NumPy 1.21 and mypy 0.900 caused a lot of errors: fix those and make the annotations better in the progress. NumPy still has some functions without annotations, so had to disable some checks. Other than that, this progress is good.