### PR TITLE
Make annotations backward-compatible

### DIFF
--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -8,18 +8,23 @@ Do not import this module directly, but rather import the main ennemi module.
 
 from __future__ import annotations
 import concurrent.futures
-from typing import Callable, Iterable, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Callable, Iterable, Optional, Sequence, Tuple, Type, TypeVar, Union
 import itertools
 import math
 import numpy as np
-import numpy.typing as npt
 from os import cpu_count
 import sys
 from ._entropy_estimators import _estimate_single_mi, _estimate_conditional_mi,\
     _estimate_semidiscrete_mi, _estimate_conditional_semidiscrete_mi, _estimate_single_entropy
 
-ArrayLike = npt.ArrayLike
-FloatArray = npt.NDArray[np.float64]
+try:
+    import numpy.typing as npt
+    FloatArray = npt.NDArray[np.float64]
+    ArrayLike = npt.ArrayLike
+except:
+    # Just stop supporting annotations altogether on NumPy 1.20 and below
+    FloatArray = np.ndarray # type: ignore
+    ArrayLike = np.ndarray # type: ignore
 GenArrayLike = TypeVar("GenArrayLike", Sequence[float], Sequence[Sequence[float]], FloatArray)
 T = TypeVar("T")
 

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -9,12 +9,15 @@ Use the `estimate_mi` method in the main ennemi module instead.
 
 from __future__ import annotations
 import numpy as np
-import numpy.typing as npt
 from scipy.spatial import cKDTree
 from typing import Union
 from warnings import warn
 
-FloatArray = npt.NDArray[np.float64]
+try:
+    import numpy.typing as npt
+    FloatArray = npt.NDArray[np.float64]
+except:
+    FloatArray = "" # type: ignore
 
 
 def _estimate_single_entropy(x: FloatArray, k: int = 3) -> float:

--- a/tests/integration/test_lorenz.py
+++ b/tests/integration/test_lorenz.py
@@ -14,12 +14,17 @@ is 7-dimensional. It also passes a two-dimensional cond_lag parameter.
 from __future__ import annotations
 from ennemi import estimate_mi
 import numpy as np
-import numpy.typing as npt
 import unittest
+
+try:
+    import numpy.typing as npt
+    FloatArray = npt.NDArray[np.float64]
+except:
+    FloatArray = "" # type: ignore
 
 class TestLorenz(unittest.TestCase):
 
-    def simulate(self) -> npt.NDArray[np.float64]:
+    def simulate(self) -> FloatArray:
         # Simulate the three Lorenz systems with 100x time resolution
         # Unlike Frenzel & Pompe, we use Euler's method for simplicity
         TIME_FACTOR = 100
@@ -60,7 +65,7 @@ class TestLorenz(unittest.TestCase):
         return y[BURNIN::TIME_FACTOR]
 
 
-    def verify_unconditional(self, data: npt.NDArray[np.float64]) -> None:
+    def verify_unconditional(self, data: FloatArray) -> None:
         # Check the top row of Frenzel & Pompe, Figure 3
         lags = np.arange(-30, 30+1)
 
@@ -85,7 +90,7 @@ class TestLorenz(unittest.TestCase):
         self.assertAlmostEqual(mi[argmax], 0.6, delta=0.03)
 
 
-    def verify_conditional(self, data: npt.NDArray[np.float64]) -> None:
+    def verify_conditional(self, data: FloatArray) -> None:
         # Check the bottom row of Figure 3
         # The conditioning variable is seven copies of the remaining variable
         # lagged symmetrically around the MI peak, as specified in the article.

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -7,13 +7,19 @@ from __future__ import annotations
 from itertools import product
 import math
 import numpy as np
-import numpy.typing as npt
 import os.path
 import pandas as pd
 import random
 from typing import List, Optional, Tuple
 import unittest
 from ennemi import estimate_entropy, estimate_mi, normalize_mi, pairwise_mi
+
+try:
+    import numpy.typing as npt
+    FloatArray = npt.NDArray[np.float64]
+except:
+    FloatArray = "" # type: ignore
+    
 
 X_Y_DIFFERENT_LENGTH_MSG = "x and y must have same length"
 X_COND_DIFFERENT_LENGTH_MSG = "x and cond must have same length"
@@ -771,7 +777,7 @@ class TestEstimateMi(unittest.TestCase):
         self.assertAlmostEqual(single_cond.item(), 0.33, delta=0.03)
         self.assertGreater(many_cond.item(), 1.0)
 
-    def _create_4d_data(self) -> Tuple[npt.NDArray[np.float64], float]:
+    def _create_4d_data(self) -> Tuple[FloatArray, float]:
         # The same dataset as in test_four_gaussians algorithm test
         rng = np.random.default_rng(2020_07_29)
         cov = np.array([[1, 0, 2, 1],
@@ -1005,7 +1011,7 @@ class TestNormalizeMi(unittest.TestCase):
 
 class TestPairwiseMi(unittest.TestCase):
 
-    def generate_normal(self, seed: int) -> npt.NDArray[np.float64]:
+    def generate_normal(self, seed: int) -> FloatArray:
         rng = np.random.default_rng(seed)
         cov = np.asarray([[1, 0.6], [0.6, 1]])
         return rng.multivariate_normal([0, 0], cov, 1000)


### PR DESCRIPTION
Of course #85 regressed on old NumPy versions.