### PR TITLE
Implement discrete MI estimation

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -5,13 +5,14 @@ with no theoretical background required.
 
 **Features:**
 - Non-linear correlation detection:
-  - Mutual information between two variables
+  - Mutual information between two variables, continous or discrete
   - Conditional MI with arbitrary-dimensional conditioning variables
-  - Discrete-continuous MI
+  - Quick overview of many-variable datasets with pairwise MI estimation
 - Practical data analysis:
-  - Interface for evaluating multiple variable pairs and time lags with one call
+  - Interfaces for evaluating multiple variable pairs and time lags with one call
   - Integrated with `pandas` data frames (optional)
   - Optimized and automatically parallelized estimation
+  - Algorithms verified to work, so that you can focus on your data
 
 This package depends only on NumPy and SciPy;
 Pandas is suggested for more enjoyable data analysis.
@@ -24,6 +25,6 @@ If you encounter any problems or have suggestions, please file an issue!
 
 ---
 
-This package has been developed at
+This package was initially developed at
 [Institute for Atmospheric and Earth System Research (INAR)](https://www.helsinki.fi/en/inar-institute-for-atmospheric-and-earth-system-research),
 University of Helsinki.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ _(Easy Nearest Neighbor Estimation of Mutual Information)_
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=polsys_ennemi&metric=coverage)](https://sonarcloud.io/dashboard?id=polsys_ennemi)
 [![DOI](https://zenodo.org/badge/247088713.svg)](https://zenodo.org/badge/latestdoi/247088713)
 
-This Python 3 package provides simple methods for estimating mutual information of continuous variables.
+This Python 3 package provides simple methods for estimating mutual information of continuous and discrete variables.
 With one method call, you can estimate several variable pairs and time lags at once.
 Both unconditional and conditional MI (including multivariate condition) are supported.
-The interface is aimed at non-linear correlation analysis.
+The interface is aimed at practical, non-linear correlation analysis.
 
 The package uses the nearest neighbor methods decscribed in:
 - Kraskov et al. (2004): Estimating mutual information. Physical Review E 69.

--- a/benchmarks/bench_discrete_mi.py
+++ b/benchmarks/bench_discrete_mi.py
@@ -1,0 +1,35 @@
+# MIT License - Copyright Petri Laarne and contributors
+# See the LICENSE.md file included in this source code package
+
+"""Benchmarks for discrete MI (both basic and conditional) estimation."""
+
+import numpy as np
+import timeit
+
+setup = """
+from ennemi import estimate_mi
+import numpy as np
+
+rng = np.random.default_rng(0)
+
+a = rng.choice(["a", "b", "c", "d"], N, p=[0.2, 0.4, 0.3, 0.1])
+b = rng.choice(["a", "b", "c", "d"], N)
+c = rng.choice(np.arange(20), N)
+d = rng.choice(np.arange(10), N)
+e = c + 2*d
+s = (a == b)
+
+data = np.asarray([a, b, c]).T
+cond2 = np.asarray([b, e]).T
+"""
+
+uncond_bench = "estimate_mi(a, data, lag=[-1, 0, 1, 2], discrete_y=True, discrete_x=True)"
+cond_bench = "estimate_mi(a, data, lag=[-1, 0, 1, 2], discrete_y=True, discrete_x=True, cond=b)"
+cond2_bench = "estimate_mi(a, data, lag=[-1, 0, 1, 2], discrete_y=True, discrete_x=True, cond=cond2)"
+
+for (name, bench) in [ ("discrete MI", uncond_bench),
+                       ("discrete CMI", cond_bench),
+                       ("discrete CMI2", cond2_bench) ]:
+    for n in [ 400, 1600, 6400, 25600 ]:
+        res = timeit.repeat(bench, setup, repeat=5, number=1, globals={"N": n})
+        print(f"{name:<13}, N={n:<4}: min={np.min(res):<6.3} s, mean={np.mean(res):<6.3} s")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -67,6 +67,12 @@ with column names matching `x`.
   If False, each column of `x` is considered a separate variable.
   If True, the $(n \times m)$ array is considered a single $m$-dimensional variable.
 
+- `discrete: bool`, default False.
+
+  If True, the variable and the optional conditioning variable are interpreted
+  as discrete variables. The result will be calculated using the mathematical
+  definition of entropy.
+
 - `mask: array_like` or None.
   
   If specified, an array of booleans that gives the input elements to use for
@@ -86,6 +92,7 @@ with column names matching `x`.
 - `drop_nan: bool`, default False.
 
   If True, all NaN (not a number) values in `x` and `cond` are masked out.
+  Not applied to discrete data.
 
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -268,6 +268,14 @@ $\infty$ nats or correlation $1$).
   If specified, an array of booleans that gives the data elements to use for
   estimation. Use this to exclude some observations from consideration.
 
+- `discrete: bool` or `array_like`, default False.
+
+  Specifies the columns that contain discrete data.
+  
+  Conditioning can be used only if the data is all-continuous or all-discrete
+  (in which case the condition is interpreted as discrete).
+  This limitation is tracked in [issue #88](https://github.com/polsys/ennemi/issues/88).
+
 - `preprocess: bool`, default True.
   
   By default, the variables are scaled to unit variance and

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -153,15 +153,16 @@ matching mask element set to `True` are used for estimation.
   while preserving the time series structure of the data. Elements of
   `x` and `cond` are masked with the lags applied.
 
-- `discrete_y: bool`, default False.
+- `discrete_x, discrete_y: bool`, default False.
 
-  If True, the `y` variable is interpreted as a discrete variable. The `x`
-  variables are still continuous. The `y` values may be non-numeric.
+  If True, the respective variable is interpreted as a discrete variable.
+  Values of the variable may be non-numeric.
 
 - `preprocess: bool`, default True.
 
   By default, the variables are scaled to unit variance and
   added with low-amplitude noise. The noise uses a fixed random seed.
+  This is not applied to discrete variables.
 
 - `drop_nan: bool`, default False.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -134,12 +134,16 @@ matching mask element set to `True` are used for estimation.
 - `k: int`, default 3.
   
   The number of neighbors to consider.
+  Ignored if both variables are discrete.
 
 - `cond: array_like`, default None.
   
   Optional 1D or 2D array of observations used for conditioning.
   Must have as many observations as `y`.
   A $(n \times m)$ array is interpreted as a single $m$-dimensional variable.
+
+  If both `discrete_x` and `discrete_y` are set, this is interpreted as a
+  discrete variable. (In future versions, this might be set explicitly.)
 
 - `cond_lag: array_like`, default 0.
 
@@ -160,7 +164,7 @@ matching mask element set to `True` are used for estimation.
 
 - `preprocess: bool`, default True.
 
-  By default, the variables are scaled to unit variance and
+  By default, continuous variables are scaled to unit variance and
   added with low-amplitude noise. The noise uses a fixed random seed.
   This is not applied to discrete variables.
 
@@ -172,6 +176,7 @@ matching mask element set to `True` are used for estimation.
 
   If True, the results will be normalized to correlation coefficient scale.
   Same as calling `normalize_mi` on the results.
+  The results are sensible only if at least one variable is continuous.
 
 - `max_threads: int` or None.
   
@@ -212,6 +217,11 @@ This is because mutual information is always
 non-negative, but `estimate_mi` may produce negative values.
 Large negative values may indicate that the data does not satisfy assumptions.
 
+The normalization is not applicable to pairs of discrete variables:
+it is not possible to get coefficient 1.0 even when the variables are completely
+determined by each other. The formula assumes that the system contains
+an infinite amount of entropy.
+
 ### Parameters
 - `mi: array_like`.
   
@@ -245,6 +255,7 @@ $\infty$ nats or correlation $1$).
 - `k: int`, default 3.
   
   The number of neighbors to consider.
+  Ignored if both variables are discrete.
 
 - `cond: array_like` or None.
   
@@ -269,6 +280,8 @@ $\infty$ nats or correlation $1$).
 - `normalize: bool`, default False.
 
   If True, the MI values will be normalized to correlation coefficient scale.
+  Same as calling `normalize_mi` on the results.
+  The results are sensible only if at least one variable is continuous.
 
 - `max_threads: int` or None.
   

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,20 +12,21 @@ with no theoretical background required.
 
 **Features:**
 - Non-linear correlation detection:
-  - Mutual information between two variables
+  - Mutual information between two variables, continous or discrete
   - Conditional MI with arbitrary-dimensional conditioning variables
-  - Discrete-continuous MI
+  - Quick overview of many-variable datasets with pairwise MI estimation
 - Practical data analysis:
-  - Interface for evaluating multiple variable pairs and time lags with one call
+  - Interfaces for evaluating multiple variable pairs and time lags with one call
   - Integrated with `pandas` data frames (optional)
   - Optimized and automatically parallelized estimation
+  - Algorithms verified to work, so that you can focus on your data
 
-`ennemi` is has been developed by Petri Laarne ([@polsys](https://github.com/polsys)) at
+`ennemi` is maintained by Petri Laarne ([@polsys](https://github.com/polsys)) and was initially developed at
 [Institute for Atmospheric and Earth System Research (INAR)](https://www.helsinki.fi/en/inar-institute-for-atmospheric-and-earth-system-research),
 University of Helsinki.
 The package is published under the MIT License.
 
-This software is also described in the SoftwareX article
+This package is also described in the SoftwareX article
 [doi:10.1016/j.softx.2021.100686](https://dx.doi.org/10.1016/j.softx.2021.100686).
 If you use this software in scientific work, please mention also the exact version number for reproducibility.
 Archived versions of the source code are available on Zenodo

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -208,7 +208,7 @@ def _estimate_conditional_entropy(x: FloatArray, cond: FloatArray, k: int, multi
             joint[i] = _call_entropy_func(xs, k, discrete)
         return joint - marginal
 
-def _call_entropy_func(xs: FloatArray, k: int, discrete: bool):
+def _call_entropy_func(xs: FloatArray, k: int, discrete: bool) -> float:
     if discrete:
         return _estimate_discrete_entropy(xs, k)
     else:
@@ -628,7 +628,7 @@ def _map_maybe_parallel(func: Callable[[T], float], params: Sequence[T],
 
 
 def _lagged_mi(param_tuple: Tuple[FloatArray, FloatArray, int, int, int, int,
-        Optional[FloatArray], Optional[FloatArray], FloatArray, bool, bool, bool]) -> float:
+        Optional[FloatArray], Optional[FloatArray], FloatArray, bool, bool, bool, bool]) -> float:
     # Unpack the param tuple used for possible cross-thread transfer
     x, y, lag, max_lag, min_lag, k, mask, cond, cond_lag,\
         discrete_x, discrete_y, preprocess, drop_nan = param_tuple

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -707,7 +707,7 @@ def _validate_masked_data(xs: FloatArray, ys: FloatArray, zs: Optional[FloatArra
         raise ValueError(NAN_MSG)
     if (not discrete_y or ys.dtype.kind in "iufc") and np.isnan(ys).any():
         raise ValueError(NAN_MSG)
-    if zs is not None and np.isnan(zs).any():
+    if not (discrete_x and discrete_y) and zs is not None and np.isnan(zs).any():
         raise ValueError(NAN_MSG)
 
 def _rescale_data(xs: FloatArray, ys: FloatArray, zs: Optional[FloatArray],

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -43,6 +43,18 @@ def _estimate_single_entropy(x: FloatArray, k: int = 3) -> float:
     # The log(2) term is because the mean is taken over double the distances
     return _psi(N) - _psi(k) + ndim * (np.mean(np.log(distances)) + np.log(2))
 
+def _estimate_discrete_entropy(x: FloatArray, k: int = 3) -> float:
+    """Estimate the discrete entropy of a n-dimensional random variable.
+
+    This is done using the mathematical definition:
+        entropy = -sum P(x) log(P(x)).
+    """
+
+    N = x.shape[0]
+    _, counts = np.unique(x, axis=0, return_counts=True)
+    probs = counts / N
+    return -np.sum(np.dot(probs, np.log(probs)))
+
 
 def _estimate_single_mi(x: FloatArray, y: FloatArray, k: int = 3) -> float:
     """Estimate the mutual information between two continuous variables.

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -228,6 +228,33 @@ def _estimate_conditional_semidiscrete_mi(x: FloatArray, y: FloatArray, cond: Fl
     return _psi(k) - np.mean(_psi(nxz) + _psi(nyz) - _psi(nz))
 
 
+def _estimate_discrete_mi(x: FloatArray, y: FloatArray, k: int = 3) -> float:
+    """Estimate unconditional MI between two variables.
+
+    The calculation proceeds by the mathematical definition:
+    joint probabilities are calculated and then used as weights to compute
+
+        MI = sum log(P(x,y) / (P(x) * P(y)) * P(x,y).
+    """
+
+    N = len(x)
+
+    x_vals, x_counts = np.unique(x, return_counts=True)
+    x_dict = dict(zip(x_vals, x_counts))
+    y_vals, y_counts = np.unique(y, return_counts=True)
+    y_dict = dict(zip(y_vals, y_counts))
+    joint_vals, joint_counts = np.unique(np.column_stack((x,y)), axis=0, return_counts=True)
+
+    def sum_term(a: FloatArray) -> float:
+        x_weight = x_dict[a[0]]
+        y_weight = y_dict[a[1]]
+        joint_weight = int(a[2]) # If values are not integers, this gets converted to string
+
+        return joint_weight * np.log(N * joint_weight / (x_weight * y_weight))
+        
+    return np.sum(np.apply_along_axis(sum_term, 1, np.column_stack((joint_vals, joint_counts)))) / N
+
+
 #
 # Digamma
 #

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -204,10 +204,7 @@ def _estimate_conditional_semidiscrete_mi(x: FloatArray, y: FloatArray, cond: Fl
 
     # Find the unique values of y
     y_values = np.unique(y)
-    
-    if len(y_values) > N / 4:
-        warn("The discrete variable has relatively many unique values." +
-            " Did you pass y and x in correct order?", UserWarning)
+    _verify_not_continuous(y_values, N)
 
     # First, create N-dimensional trees for variables
     # The full space is partitioned according to y levels
@@ -239,6 +236,13 @@ def _estimate_conditional_semidiscrete_mi(x: FloatArray, y: FloatArray, cond: Fl
 
     return _psi(k) - np.mean(_psi(nxz) + _psi(nyz) - _psi(nz))
 
+def _verify_not_continuous(values: FloatArray, N: int) -> None:
+    if len(values) > N / 4:
+        warn("A discrete variable has relatively many unique values." +
+            " Have you set marked the discrete variables in correct order?" +
+            " If both X and Y are discrete, the conditioning variable cannot be continuous" +
+            " (this limitation can be lifted in the future).", UserWarning)
+
 
 def _estimate_discrete_mi(x: FloatArray, y: FloatArray) -> float:
     """Estimate unconditional MI between two discrete variables.
@@ -260,6 +264,9 @@ def _estimate_discrete_mi(x: FloatArray, y: FloatArray) -> float:
     y_vals, y_counts = np.unique(data[:,1], return_counts=True)
     y_dict = dict(zip(y_vals, y_counts))
     joint_vals, joint_counts = np.unique(data, axis=0, return_counts=True)
+
+    _verify_not_continuous(x_vals, N)
+    _verify_not_continuous(y_vals, N)
 
     def sum_term(a: FloatArray) -> float:
         x_weight = x_dict[a[0]]

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -251,16 +251,20 @@ def _estimate_discrete_mi(x: FloatArray, y: FloatArray) -> float:
 
     N = len(x)
 
-    x_vals, x_counts = np.unique(x, return_counts=True)
+    # If one variable is string and the other an integer, this converts them both to strings.
+    # Without this, we get into trouble searching for strings in a dictionary of integers.
+    data = np.column_stack((x,y))
+
+    x_vals, x_counts = np.unique(data[:,0], return_counts=True)
     x_dict = dict(zip(x_vals, x_counts))
-    y_vals, y_counts = np.unique(y, return_counts=True)
+    y_vals, y_counts = np.unique(data[:,1], return_counts=True)
     y_dict = dict(zip(y_vals, y_counts))
-    joint_vals, joint_counts = np.unique(np.column_stack((x,y)), axis=0, return_counts=True)
+    joint_vals, joint_counts = np.unique(data, axis=0, return_counts=True)
 
     def sum_term(a: FloatArray) -> float:
         x_weight = x_dict[a[0]]
         y_weight = y_dict[a[1]]
-        joint_weight = int(a[2]) # If values are not integers, this might get converted to a string
+        joint_weight = int(a[2]) # This too might have been converted to a string
 
         return joint_weight * np.log(N * joint_weight / (x_weight * y_weight))
         

--- a/tests/integration/test_entropy_identities.py
+++ b/tests/integration/test_entropy_identities.py
@@ -35,3 +35,31 @@ class TestEntropyIdentities(unittest.TestCase):
         joint = estimate_entropy(np.column_stack((x,y)), multidim=True)
 
         self.assertAlmostEqual(np.sum(marginal) - joint, mi, delta=0.02)
+
+    def test_discrete_mi_as_conditional_entropy_difference(self) -> None:
+        # A -> X, the others are random
+        rng = np.random.default_rng(2)
+        x = rng.choice(["A", "B", "C", "D"], 200, p=[0.3, 0.1, 0.4, 0.2])
+        y = rng.choice(["X", "Y", "Z", "W"], 200, p=[0.1, 0.1, 0.2, 0.6])
+        y[x == "A"] = "X"
+
+        mi = estimate_mi(y, x, discrete_y=True, discrete_x=True)
+        ent_x = estimate_entropy(x, discrete=True)
+        cond_ent = estimate_entropy(x, cond=y, discrete=True)
+
+        self.assertAlmostEqual(ent_x - cond_ent, mi, delta=1e-6)
+
+    def test_discrete_mi_as_sum_of_entropies(self) -> None:
+        # A -> X and B -> Y, the others are random
+        rng = np.random.default_rng(2)
+        x = rng.choice(["A", "B", "C", "D", "E"], 200, p=[0.2, 0.2, 0.3, 0.2, 0.1])
+        y = rng.choice(["X", "Y", "Z", "W"], 200, p=[0.1, 0.2, 0.2, 0.5])
+        y[x == "A"] = "X"
+        y[x == "B"] = "Y"
+
+        mi = estimate_mi(y, x, discrete_y=True, discrete_x=True)
+        marginal = estimate_entropy(np.column_stack((x, y)), discrete=True)
+        joint = estimate_entropy(np.column_stack((x,y)), multidim=True, discrete=True)
+
+        self.assertAlmostEqual(np.sum(marginal) - joint, mi, delta=1e-6)
+

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -932,7 +932,7 @@ class TestEstimateMi(unittest.TestCase):
 
         mi = estimate_mi(y, x, discrete_x=True, discrete_y=True)
         self.assertAlmostEqual(mi, 0, delta=1e-6)
-        
+
     def test_both_discrete_independent_bools(self) -> None:
         x = np.tile([True, False], 100)
         y = np.repeat([False, True], 100)
@@ -958,6 +958,19 @@ class TestEstimateMi(unittest.TestCase):
             + 0.4 * math.log(0.4 / (0.6 * 0.8))\
             + 0.2 * math.log(0.2 / (0.6 * 0.2))
         self.assertAlmostEqual(mi, expected, delta=1e-6)
+
+    def test_both_discrete_with_lag(self) -> None:
+        # Y equals X with lag of two time steps
+        rng = np.random.default_rng(2021_07_29)
+        x = rng.choice(["a", "b"], 500)
+        y = np.roll(x, 2)
+
+        mi = estimate_mi(y, x, discrete_x=True, discrete_y=True, lag=[0, 1, 2])
+
+        # Some error due to randomness is expected
+        self.assertAlmostEqual(mi[0,0], 0.0, delta=0.01)
+        self.assertAlmostEqual(mi[1,0], 0.0, delta=0.01)
+        self.assertAlmostEqual(mi[2,0], math.log(2), delta=0.01)
 
 
     def test_preprocess(self) -> None:

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -305,6 +305,30 @@ class TestEstimateEntropy(unittest.TestCase):
                 except:
                     self.fail(f"Exception occurred; multidim={multidim}, k={k}")
 
+    def test_discrete_1d(self) -> None:
+        data = np.repeat(["a", "a", "a", "b", "b", "c"], 20)
+        result = estimate_entropy(data, discrete=True)
+
+        expected = -(3/6*math.log(3/6) + 2/6*math.log(2/6) + 1/6*math.log(1/6))
+        self.assertAlmostEqual(result, expected, delta=1e-6)
+
+    def test_discrete_2d(self) -> None:
+        chars = ["a", "b", "c", "d", "e"]
+        data = np.column_stack((np.tile(chars, 5), np.repeat(chars, 5)))
+        result = estimate_entropy(data, discrete=True, multidim=True)
+
+        self.assertAlmostEqual(result, math.log(5*5), delta=1e-6)
+
+    def test_discrete_condition(self) -> None:
+        data = np.repeat(["a", "b", "c", "d"], 20)
+        cond = np.repeat(["even", "odd", "even", "odd"], 20)
+
+        uncond = estimate_entropy(data, discrete=True)
+        cond = estimate_entropy(data, discrete=True, cond=cond)
+
+        self.assertAlmostEqual(uncond, math.log(4), delta=1e-6)
+        self.assertAlmostEqual(cond, math.log(2), delta=1e-6)
+
 
 class TestEstimateMi(unittest.TestCase):
     

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -891,6 +891,31 @@ class TestEstimateMi(unittest.TestCase):
         self.assertAlmostEqual(mi, 0.8, delta=0.02)
 
 
+    def test_discrete_many_values_warning(self) -> None:
+        rng = np.random.default_rng(2021_08_03)
+        cont = rng.normal(size=100)
+        disc = rng.choice([0, 1, 2], size=100)
+
+        # If the parameters are put the wrong way, a warning is emitted
+        with self.assertWarns(UserWarning):
+            _ = estimate_mi(cont, disc, discrete_y=True)
+        with self.assertWarns(UserWarning):
+            _ = estimate_mi(disc, cont, discrete_x=True)
+
+        # This also applies when both are discrete
+        with self.assertWarns(UserWarning):
+            _ = estimate_mi(disc, cont, discrete_y=True, discrete_x=True)
+        with self.assertWarns(UserWarning):
+            _ = estimate_mi(cont, disc, discrete_y=True, discrete_x=True)
+
+        # ...and to the condition as well
+        with self.assertWarns(UserWarning):
+            _ = estimate_mi(disc, cont, cond=disc, discrete_y=True, discrete_x=True)
+        with self.assertWarns(UserWarning):
+            _ = estimate_mi(cont, disc, cond=disc, discrete_y=True, discrete_x=True)
+        with self.assertWarns(UserWarning):
+            _ = estimate_mi(disc, disc, cond=cont, discrete_y=True, discrete_x=True)
+
     def test_discrete_y_continuous_x(self) -> None:
         # See the two_disjoint_uniforms algorithm test
         rng = np.random.default_rng(51)
@@ -899,10 +924,6 @@ class TestEstimateMi(unittest.TestCase):
 
         mi = estimate_mi(y, x, discrete_y=True)
         self.assertAlmostEqual(mi, math.log(2), delta=0.02)
-
-        # If the parameters are put the wrong way, a warning is emitted
-        with self.assertWarns(UserWarning):
-            _ = estimate_mi(x, y, discrete_y=True)
 
         # Symmetry
         mi2 = estimate_mi(x, y, discrete_x=True)


### PR DESCRIPTION
Closes #87. Implemented discrete MI, both basic and conditional, and discrete entropy estimation.

- The algorithm is very straightforward
- Not especially optimized for performance, though better than toying with discrete entropy (basic MI takes ~0.6x time; with 2D conditions, entropy is slightly faster)
- Limitation: no mixed conditioning variables (see #88)

Still requires some documentation work (#75).