### PR TITLE
Test with Python 3.10

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,18 +20,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
         # Save a bit of resources by running only some combinations:
-        # Windows 3.7 and 3.9; macOS 3.8; Ubuntu 3.7 and 3.9
+        # Windows 3.7 and 3.10; macOS 3.8 and 3.9; Ubuntu 3.7 and 3.10
         exclude:
           - os: windows-latest
             python-version: 3.8
+          - os: windows-latest
+            python-version: 3.9
           - os: macos-latest
             python-version: 3.7
           - os: macos-latest
-            python-version: 3.9
+            python-version: 3.10
           - os: ubuntu-latest
             python-version: 3.8
+          - os: ubuntu-latest
+            python-version: 3.9
 
     steps:
       - name: Check out code
@@ -47,7 +51,7 @@ jobs:
           pip install -e .[dev]
       
       - name: Run unit tests (with coverage)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
         # We have to rename the path in coverage.xml since Sonar is run in Docker
         # and has a different view of the file system
         run: |
@@ -56,24 +60,22 @@ jobs:
           sed 's/\/home\/runner\/work\/ennemi\/ennemi/\/github\/workspace/g' coverage.xml > coverage-mod.xml
       
       - name: Run unit tests (no coverage)
-        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.9'
+        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.10'
         run: |
           python -m pytest tests/unit/ --junit-xml=test-results.xml
 
       - name: Run type checker
-        # NumPy 1.20 with type annotations does not support Python 3.6
-        if: matrix.python-version != '3.6'
         run: |
           python -m mypy ennemi/ tests/unit tests/integration tests/pandas
 
       - name: Try building the package
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
         run: |
           pip install setuptools wheel
           python setup.py sdist bdist_wheel
       
       - name: Run Sonar code analysis
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,22 +20,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
         # Save a bit of resources by running only some combinations:
         # Windows 3.7 and 3.10; macOS 3.8 and 3.9; Ubuntu 3.7 and 3.10
         exclude:
           - os: windows-latest
-            python-version: 3.8
+            python-version: '3.8'
           - os: windows-latest
-            python-version: 3.9
+            python-version: '3.9'
           - os: macos-latest
-            python-version: 3.7
+            python-version: '3.7'
           - os: macos-latest
-            python-version: 3.10
+            python-version: '3.10'
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: '3.8'
           - os: ubuntu-latest
-            python-version: 3.9
+            python-version: '3.9'
 
     steps:
       - name: Check out code

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-16.04, windows-2016 ]
+        os: [ ubuntu-18.04, windows-2016 ]
 
     steps:
       - name: Check out code

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,7 +16,7 @@ with no theoretical background required.
 
 This package depends only on NumPy and SciPy;
 Pandas is suggested for more enjoyable data analysis.
-Python 3.6+ on the latest macOS, Ubuntu and Windows versions
+Python 3.7+ on the latest macOS, Ubuntu and Windows versions
 is officially supported.
 
 For more information on theoretical background and usage, please see the

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -16,8 +16,10 @@ from warnings import warn
 try:
     import numpy.typing as npt
     FloatArray = npt.NDArray[np.float64]
+    IntArray = npt.NDArray[np.int64]
 except:
     FloatArray = "" # type: ignore
+    IntArray = "" # type: ignore
 
 
 def _estimate_single_entropy(x: FloatArray, k: int = 3) -> float:
@@ -321,7 +323,7 @@ def _estimate_conditional_discrete_mi(x: FloatArray, y: FloatArray, cond: FloatA
 # Digamma
 #
 
-def _psi(x: Union[int, FloatArray]) -> FloatArray:
+def _psi(x: Union[int, FloatArray, IntArray]) -> FloatArray:
     """A replacement for scipy.special.psi, for non-negative integers only.
     
     This is slightly faster than the SciPy version (not that it's a bottleneck),

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,10 @@
 [mypy]
 warn_unused_configs = True
 warn_redundant_casts = True
-warn_unused_ignores = True
 warn_unreachable = True
+# BUG: There is one line in _driver.py that errors on NumPy 1.22 but not 1.21
+#      It seems necessary to ignore, but that flags 'unused ignore' on 1.21...
+#warn_unused_ignores = True
 
 disallow_untyped_defs = True
 disallow_incomplete_defs = True

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Scientific/Engineering :: Mathematics",

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
     # At least pandas requires numpy 1.17.3+ (security fixes), we should too
     install_requires = [ "numpy>=1.17.5", "numpy<2.0", "scipy~=1.4" ],
     extras_require = {
-        "dev": [ "pandas~=1.0", "pytest~=5.4", "mypy~=0.770" ]
+        "dev": [ "pandas~=1.0", "pytest~=6.2", "mypy~=0.770" ]
     }
 )


### PR DESCRIPTION
- Adds Python 3.10 to the test matrix. The CI for this PR will also invoke the latest NumPy.
- Closes #93: migrates integration tests from Ubuntu 16.04 to 18.04.
- Closes #94: fixed PyPI description and metadata with correct Python versions.