### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, windows-2016 ]
+        os: [ ubuntu-18.04, windows-2019 ]
 
     steps:
       - name: Check out code
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies with custom versions
         # Note: This must be kept in sync with the minimum versions in setup.py
         run: |
-          pip install numpy==1.17.5 scipy==1.4 pytest~=5.4
+          pip install numpy==1.19.0 scipy==1.5 pytest~=5.4
           pip install --no-deps -e .
 
       - name: Run integration tests (without pandas)

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,10 @@
 warn_unused_configs = True
 warn_redundant_casts = True
 warn_unreachable = True
-warn_unused_ignores = True
+# BUG: There is one line in _driver.py that errors on NumPy 1.22 but not 1.21
+#      It seems necessary to ignore, but that flags 'unused ignore' on 1.21...
+#      It also fails in CI but not locally?
+warn_unused_ignores = False
 
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
@@ -11,6 +14,9 @@ disallow_any_explicit = True
 disallow_any_generics = True
 disallow_subclassing_any = True
 no_implicit_optional = True
+
+# Not all of NumPy is annotated yet
+disallow_untyped_calls = False
 
 # BUG: assertAlmostEqual(ndarray, float, float) does not work
 # because mypy does not understand the implicit conversion.

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,9 +2,7 @@
 warn_unused_configs = True
 warn_redundant_casts = True
 warn_unreachable = True
-# BUG: There is one line in _driver.py that errors on NumPy 1.22 but not 1.21
-#      It seems necessary to ignore, but that flags 'unused ignore' on 1.21...
-#warn_unused_ignores = True
+warn_unused_ignores = True
 
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
@@ -13,9 +11,6 @@ disallow_any_explicit = True
 disallow_any_generics = True
 disallow_subclassing_any = True
 no_implicit_optional = True
-
-# Not all of NumPy is annotated yet
-disallow_untyped_calls = False
 
 # BUG: assertAlmostEqual(ndarray, float, float) does not work
 # because mypy does not understand the implicit conversion.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(description_file, encoding="utf-8") as f:
 
 setup(
     name = "ennemi",
-    version = "1.1.1",
+    version = "1.2.0",
     description = "Non-linear correlation detection with mutual information",
     long_description = long_description,
     long_description_content_type = "text/markdown",
@@ -47,8 +47,7 @@ setup(
     packages = [ "ennemi" ],
     package_data = { "ennemi": ["py.typed"] },
     python_requires = "~=3.7",
-    # At least pandas requires numpy 1.17.3+ (security fixes), we should too
-    install_requires = [ "numpy>=1.17.5", "numpy<2.0", "scipy~=1.4" ],
+    install_requires = [ "numpy~=1.19", "scipy~=1.5" ],
     extras_require = {
         "dev": [ "pandas~=1.0", "pytest~=6.2", "mypy~=0.770" ]
     }


### PR DESCRIPTION
- Increase version number to `1.2.0`
- Increase minimum NumPy to 1.19 and SciPy to 1.5 (kept Python 3.7 still supported even though not officially required; I feel that Python upgrades happen at slower pace in practice)
- Fix #95 by upgrading integration tests to supported Windows image