### PR TITLE
Bump version and dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,25 +19,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ '3.8', '3.9', '3.10' ]
+        os: [ ubuntu-latest, macos-12, windows-latest ]
+        python-version: [ '3.9', '3.10', '3.11' ]
         # Save a bit of resources by running only some combinations:
-        # Windows 3.8; macOS 3.9; Ubuntu 3.10
-        # Python 3.7 is only used in integration tests
-        # Note that some steps are only run on Ubuntu/3.10 (must update when 3.11 comes)
+        # Windows 3.9; macOS 3.10; Ubuntu 3.11
+        # Python 3.8 is only used in integration tests
+        # Note that some steps are only run on Ubuntu/3.11 (must update when 3.12 comes)
         exclude:
           - os: windows-latest
-            python-version: '3.9'
+            python-version: '3.10'
           - os: windows-latest
-            python-version: '3.10'
+            python-version: '3.11'
           - os: macos-latest
-            python-version: '3.8'
+            python-version: '3.9'
           - os: macos-latest
-            python-version: '3.10'
-          - os: ubuntu-latest
-            python-version: '3.8'
+            python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.9'
+          - os: ubuntu-latest
+            python-version: '3.10'
 
     steps:
       - name: Check out code
@@ -53,7 +53,7 @@ jobs:
           pip install -e .[dev]
       
       - name: Run unit tests (with coverage)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         # We have to rename the path in coverage.xml since Sonar is run in Docker
         # and has a different view of the file system
         run: |
@@ -62,12 +62,12 @@ jobs:
           sed 's/\/home\/runner\/work\/ennemi\/ennemi/\/github\/workspace/g' coverage.xml > coverage-mod.xml
       
       - name: Run unit tests (no coverage)
-        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.10'
+        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.11'
         run: |
           python -m pytest tests/unit/ --junit-xml=test-results.xml
 
       - name: Try building the package
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         run: |
           pip install setuptools wheel
           python setup.py sdist bdist_wheel
@@ -77,7 +77,7 @@ jobs:
           python -m mypy ennemi/ tests/unit tests/integration tests/pandas
       
       - name: Run Sonar code analysis
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,9 +30,9 @@ jobs:
             python-version: '3.10'
           - os: windows-latest
             python-version: '3.11'
-          - os: macos-latest
+          - os: macos-12
             python-version: '3.9'
-          - os: macos-latest
+          - os: macos-12
             python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.9'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,21 +17,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, windows-2019 ]
+        os: [ ubuntu-20.04, windows-2019, macos-11 ]
 
     steps:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies with custom versions
         # Note: This must be kept in sync with the minimum versions in setup.py
         run: |
-          pip install numpy==1.19.0 scipy==1.5 pytest~=5.4
+          pip install numpy==1.21.0 scipy==1.7 pytest~=6.2
           pip install --no-deps -e .
 
       - name: Run integration tests (without pandas)

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -16,7 +16,7 @@ with no theoretical background required.
 
 This package depends only on NumPy and SciPy;
 Pandas is suggested for more enjoyable data analysis.
-Python 3.7+ on the latest macOS, Ubuntu and Windows versions
+Python 3.8+ on the latest macOS, Ubuntu and Windows versions
 is officially supported.
 
 For more information on theoretical background and usage, please see the

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can also follow the development by clicking `Watch releases` on the GitHub p
 
 ## Getting started
 
-This package requires Python 3.7 or higher,
+This package requires Python 3.8 or higher,
 and it is tested to work on the latest versions of Ubuntu, macOS and Windows.
 The only hard dependencies are reasonably recent versions of NumPy and SciPy;
 Pandas is strongly suggested for more enjoyable data analysis.

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -20,14 +20,9 @@ from ._entropy_estimators import _estimate_single_mi, _estimate_conditional_mi,\
     _estimate_semidiscrete_mi, _estimate_conditional_semidiscrete_mi,\
     _estimate_single_entropy, _estimate_discrete_entropy
 
-try:
-    import numpy.typing as npt
-    FloatArray = npt.NDArray[np.float64]
-    ArrayLike = npt.ArrayLike
-except:
-    # Just stop supporting annotations altogether on NumPy 1.20 and below
-    FloatArray = np.ndarray # type: ignore
-    ArrayLike = np.ndarray # type: ignore
+import numpy.typing as npt
+FloatArray = npt.NDArray[np.float64]
+ArrayLike = npt.ArrayLike
 GenArrayLike = TypeVar("GenArrayLike", Sequence[float], Sequence[Sequence[float]], FloatArray)
 T = TypeVar("T")
 
@@ -220,7 +215,7 @@ def _estimate_conditional_entropy(x: FloatArray, cond: FloatArray, k: int, multi
 
 def _call_entropy_func(xs: FloatArray, k: int, discrete: bool) -> float:
     if discrete:
-        return _estimate_discrete_entropy(xs, k)
+        return _estimate_discrete_entropy(xs)
     else:
         return _estimate_single_entropy(xs, k)
 

--- a/ennemi/_entropy_estimators.py
+++ b/ennemi/_entropy_estimators.py
@@ -13,13 +13,9 @@ from scipy.spatial import cKDTree
 from typing import Union
 from warnings import warn
 
-try:
-    import numpy.typing as npt
-    FloatArray = npt.NDArray[np.float64]
-    IntArray = npt.NDArray[np.int64]
-except:
-    FloatArray = "" # type: ignore
-    IntArray = "" # type: ignore
+import numpy.typing as npt
+FloatArray = npt.NDArray[np.float64]
+IntArray = npt.NDArray[np.int64]
 
 
 def _estimate_single_entropy(x: FloatArray, k: int = 3) -> float:
@@ -45,7 +41,7 @@ def _estimate_single_entropy(x: FloatArray, k: int = 3) -> float:
     # The log(2) term is because the mean is taken over double the distances
     return _psi(N) - _psi(k) + ndim * (np.mean(np.log(distances)) + np.log(2))
 
-def _estimate_discrete_entropy(x: FloatArray, k: int = 3) -> float:
+def _estimate_discrete_entropy(x: FloatArray) -> float:
     """Estimate the discrete entropy of a n-dimensional random variable.
 
     This is done using the mathematical definition:
@@ -250,8 +246,8 @@ def _estimate_conditional_semidiscrete_mi(x: FloatArray, y: FloatArray, cond: Fl
 
     return _psi(k) - np.mean(_psi(nxz) + _psi(nyz) - _psi(nz))
 
-def _verify_not_continuous(values: FloatArray, N: int) -> None:
-    if len(values) > N / 4:
+def _verify_not_continuous(values: FloatArray, n: int) -> None:
+    if len(values) > n / 4:
         warn("A discrete variable has relatively many unique values." +
             " Have you set marked the discrete variables in correct order?" +
             " If both X and Y are discrete, the conditioning variable cannot be continuous" +

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(description_file, encoding="utf-8") as f:
 
 setup(
     name = "ennemi",
-    version = "1.2.1",
+    version = "1.3.0",
     description = "Non-linear correlation detection with mutual information",
     long_description = long_description,
     long_description_content_type = "text/markdown",
@@ -25,10 +25,10 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Scientific/Engineering :: Mathematics",
@@ -46,9 +46,9 @@ setup(
 
     packages = [ "ennemi" ],
     package_data = { "ennemi": ["py.typed"] },
-    python_requires = "~=3.7",
-    install_requires = [ "numpy~=1.19", "scipy~=1.5" ],
+    python_requires = "~=3.8",
+    install_requires = [ "numpy~=1.21", "scipy~=1.7" ],
     extras_require = {
-        "dev": [ "pandas~=1.0", "pytest~=6.2", "mypy~=0.770" ]
+        "dev": [ "pandas~=1.0", "pytest~=6.2", "mypy~=0.991" ]
     }
 )

--- a/tests/integration/test_unbiasedness.py
+++ b/tests/integration/test_unbiasedness.py
@@ -17,12 +17,12 @@ class TestUnbiasedness(unittest.TestCase):
         cov = [[1, 0.8], [0.8, 1]]
         data = rng.multivariate_normal([0, 0], cov, size=20_000)
         
-        mi_3 = estimate_mi(data[:,0], data[:,1], k=3)
-        mi_100 = estimate_mi(data[:,0], data[:,1], k=100)
+        mi_3 = estimate_mi(data[:,0], data[:,1], k=3).item()
+        mi_100 = estimate_mi(data[:,0], data[:,1], k=100).item()
 
         # Large k will have some bias, small k should not
         expected = -0.5 * log(1 - 0.8**2)
-        self.assertAlmostEqual(mi_3.item(), expected, delta=0.005)
+        self.assertAlmostEqual(mi_3, expected, delta=0.005)
         self.assertGreater(abs(mi_100 - expected), abs(mi_3 - expected) + 0.005)
 
     def test_unconditional_mi_independence(self) -> None:
@@ -30,11 +30,11 @@ class TestUnbiasedness(unittest.TestCase):
         cov = [[1, 0], [0, 1]]
         data = rng.multivariate_normal([0, 0], cov, size=20_000)
         
-        mi_3 = estimate_mi(data[:,0], data[:,1], k=3)
-        mi_100 = estimate_mi(data[:,0], data[:,1], k=100)
+        mi_3 = estimate_mi(data[:,0], data[:,1], k=3).item()
+        mi_100 = estimate_mi(data[:,0], data[:,1], k=100).item()
 
         # Large k should be better for independence testing
-        self.assertAlmostEqual(mi_100.item(), 0.0, delta=0.004)
+        self.assertAlmostEqual(mi_100, 0.0, delta=0.004)
         self.assertGreater(mi_3 - mi_100, 0.002)
 
 
@@ -44,11 +44,11 @@ class TestUnbiasedness(unittest.TestCase):
         x = rng.normal(0.0, 1.0, size=20_000)
         y = rng.normal(0.0, 1.0, size=20_000)
         
-        mi_3 = estimate_mi(x, x+y, cond=x, k=3)
-        mi_100 = estimate_mi(x, x+y, cond=x, k=100)
+        mi_3 = estimate_mi(x, x+y, cond=x, k=3).item()
+        mi_100 = estimate_mi(x, x+y, cond=x, k=100).item()
 
         # Large k should be better for independence testing here as well
-        self.assertAlmostEqual(mi_100.item(), 0.0, delta=0.005)
+        self.assertAlmostEqual(mi_100, 0.0, delta=0.005)
         self.assertGreater(abs(mi_3 - mi_100), 0.05)
 
 
@@ -56,8 +56,8 @@ class TestUnbiasedness(unittest.TestCase):
         rng = np.random.default_rng(0)
         x = rng.normal(size=20_000)
 
-        h_1 = estimate_entropy(x, k=1)
-        h_100 = estimate_entropy(x, k=100)
+        h_1 = estimate_entropy(x, k=1).item()
+        h_100 = estimate_entropy(x, k=100).item()
 
         # Small k has positive bias, large k has negative bias
         expected = 0.5*log(2*pi*e)
@@ -65,8 +65,8 @@ class TestUnbiasedness(unittest.TestCase):
         self.assertLess(h_100, expected - 0.005)
 
         # Still, both are reasonably close, and large k is closer
-        self.assertAlmostEqual(h_1.item(), expected, delta=0.04)
-        self.assertAlmostEqual(h_100.item(), expected, delta=0.01)
+        self.assertAlmostEqual(h_1, expected, delta=0.04)
+        self.assertAlmostEqual(h_100, expected, delta=0.01)
 
 
     def test_conditional_entropy_bias(self) -> None:
@@ -76,10 +76,10 @@ class TestUnbiasedness(unittest.TestCase):
         cov = np.asarray([[1, 0.6, 0.3], [0.6, 2, 0.1], [0.3, 0.1, 1]])
         data = rng.multivariate_normal([0, 0, 0], cov, size=20_000)
 
-        h_5 = estimate_entropy(data[:,:2], cond=data[:,2], multidim=True, k=5)
-        h_50 = estimate_entropy(data[:,:2], cond=data[:,2], multidim=True, k=50)
+        h_5 = estimate_entropy(data[:,:2], cond=data[:,2], multidim=True, k=5).item()
+        h_50 = estimate_entropy(data[:,:2], cond=data[:,2], multidim=True, k=50).item()
 
         # Again, large k appears to have more negative bias
         expected = 0.5 * (log(np.linalg.det(2 * pi * e * cov)) - log(2 * pi * e))
-        self.assertAlmostEqual(h_5.item(), expected, delta=0.005)
-        self.assertAlmostEqual(h_50.item(), expected, delta=0.03)
+        self.assertAlmostEqual(h_5, expected, delta=0.005)
+        self.assertAlmostEqual(h_50, expected, delta=0.03)

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -212,7 +212,7 @@ class TestEstimateEntropy(unittest.TestCase):
         self.assertLess(marginal[0], -0.5)
         self.assertLess(marginal[1], -0.5)
         self.assertLess(marginal[2], -0.5)
-        self.assertLess(multidim, -1.5)
+        self.assertLess(multidim.item(), -1.5)
 
     def test_conditional_entropy_with_independent_condition(self) -> None:
         rng = np.random.default_rng(6)
@@ -233,8 +233,8 @@ class TestEstimateEntropy(unittest.TestCase):
         cond = np.concatenate((unif, rng.normal(0, 1, size=400)))
         mask = np.concatenate((np.full(1000, True), np.full(400, False)))
 
-        unmasked = estimate_entropy(data, cond=cond)
-        masked = estimate_entropy(data, cond=cond, mask=mask)
+        unmasked = estimate_entropy(data, cond=cond).item()
+        masked = estimate_entropy(data, cond=cond, mask=mask).item()
 
         self.assertLess(masked, unmasked - 1)
         self.assertLess(masked, -5)
@@ -690,13 +690,13 @@ class TestEstimateMi(unittest.TestCase):
         mask[150:450] = False
 
         # The unmasked estimation is clearly incorrect
-        unmasked = estimate_mi(y, x, mask=None)
+        unmasked = estimate_mi(y, x, mask=None).item()
         self.assertLess(unmasked, 0.4)
 
         # Constraining to the correct dataset produces correct results
         expected = -0.5 * math.log(1 - 0.8**2)
-        masked = estimate_mi(y, x, mask=mask)
-        self.assertAlmostEqual(masked.item(), expected, delta=0.03)
+        masked = estimate_mi(y, x, mask=mask).item()
+        self.assertAlmostEqual(masked, expected, delta=0.03)
 
     def test_mask_as_list(self) -> None:
         x = list(range(300)) # type: List[float]
@@ -706,7 +706,7 @@ class TestEstimateMi(unittest.TestCase):
         y = list(range(300, 0, -1))
         mask = [ True, False ] * 150
 
-        self.assertGreater(estimate_mi(y, x, lag=1, mask=mask), 3)
+        self.assertGreater(estimate_mi(y, x, lag=1, mask=mask).item(), 3)
 
     def test_mask_and_lag(self) -> None:
         # Only even y and odd x elements are preserved
@@ -720,7 +720,7 @@ class TestEstimateMi(unittest.TestCase):
         x[mask] = 0
         y[np.logical_not(mask)] = 0
 
-        actual = estimate_mi(y, x, lag=1, mask=mask)
+        actual = estimate_mi(y, x, lag=1, mask=mask).item()
         self.assertGreater(actual, 4)
 
     def test_conditional_mi_with_several_lags(self) -> None:
@@ -736,7 +736,7 @@ class TestEstimateMi(unittest.TestCase):
 
         # As a consistency check, the non-conditional MI should be large
         noncond = estimate_mi(z, y, k=5, lag=1)
-        self.assertGreater(noncond, 1)
+        self.assertGreater(noncond.item(), 1)
 
         # Then the conditional MI
         actual = estimate_mi(z, y, lag=[0,1], k=5, cond=x, cond_lag=[1, 2])

--- a/tests/unit/test_entropy_estimators.py
+++ b/tests/unit/test_entropy_estimators.py
@@ -236,7 +236,7 @@ class TestEstimateConditionalMi(unittest.TestCase):
 
         actual = _estimate_conditional_mi(data[:,0], data[:,1], data[:,2])
         expected = 0.5 * (log(8) + log(35) - log(9) - log(24))
-        self.assertAlmostEqual(actual, expected, delta=0.015)
+        self.assertAlmostEqual(actual, expected, delta=0.025)
 
     def test_four_gaussians(self) -> None:
         # As above, but now the condition is two-dimensional.


### PR DESCRIPTION
Fixes #110. Contributes to #111.

- Bump version number to 1.3
- Drop support for Python 3.7 and older NumPy/SciPy
- Remove typing workarounds for NumPy 1.20 and lower
- Bump dev dependencies and CI operating systems, add Python 3.11 to test matrix
- Add macOS 11 to "old versions" integration test and use macOS 12 in unit tests