### PR TITLE
Enable pandas 2.0 in tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,11 +1,6 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
   pull_request:
     branches: [ master ]
     paths-ignore:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,11 +38,19 @@ jobs:
         run: |
           python -m pytest tests/integration/
 
-      - name: Install pandas
+      - name: Install pandas 1.0
         run: |
           pip install pandas==1.0
 
-      - name: Run integration tests (with pandas)
+      - name: Run integration tests (with pandas 1.0)
+        run: |
+          python -m pytest tests/pandas/
+
+      - name: Install pandas 2.0
+        run: |
+          pip install pandas==2.0
+
+      - name: Run integration tests (with pandas 2.0)
         run: |
           python -m pytest tests/pandas/
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     python_requires = "~=3.8",
     install_requires = [ "numpy~=1.21", "scipy~=1.7" ],
     extras_require = {
-        "dev": [ "pandas~=1.0", "pytest~=6.2", "mypy~=0.991" ]
+        "dev": [ "pandas>1.0", "pytest~=6.2", "mypy~=0.991" ]
     }
 )


### PR DESCRIPTION
Seems that we are compatible with pandas 2.0. Version 1.0 is still supported (and guarded by integration tests).

Also removed the CI workflow trigger on `main` pushes, since we always go through PRs (and there are no concurrent merges...).