### PR TITLE
Bump dependencies and add Python 3.13

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         # Save a bit of resources by running only some combinations:
-        # Windows 3.11; macOS 3.10; Ubuntu 3.12
-        # Additionally, macOS on ARM processor is tested
+        # Windows 3.11; macOS 3.13; Ubuntu 3.12 (as of this writing, cached 3.13 is on macOS only)
+        # macOS is tested both on ARM and x86-64 processors
         # Code coverage, SonarCloud and test package build are only done once
         include:
           - os: ubuntu-latest
@@ -25,11 +25,11 @@ jobs:
           - os: windows-latest
             python-version: '3.11'
             analysis: false
-          - os: macos-latest
-            python-version: '3.10'
+          - os: macos-13
+            python-version: '3.13'
             analysis: false
-          - os: macos-14
-            python-version: '3.12'
+          - os: macos-15
+            python-version: '3.13'
             analysis: false
 
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,35 +17,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-2019, macos-11 ]
+        os: [ windows-2019, macos-12 ]
 
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies with custom versions
         # Note: This must be kept in sync with the minimum versions in setup.py
         run: |
-          pip install numpy==1.23.0 scipy==1.9.0 pytest~=8.0
+          pip install numpy==1.24.0 scipy==1.10.0 pytest~=8.0
           pip install --no-deps -e .
 
       - name: Run integration tests (without pandas)
         run: |
           python -m pytest tests/integration/
-
-      - name: Install pandas 1.x
-        # This too needs to be updated at some cadence (mainly due to NumPy support of pandas)
-        run: |
-          pip install pandas==1.5.0
-
-      - name: Run integration tests (with pandas 1.x)
-        run: |
-          python -m pytest tests/pandas/
 
       - name: Install pandas 2.0
         run: |

--- a/ennemi/_driver.py
+++ b/ennemi/_driver.py
@@ -67,16 +67,10 @@ def normalize_mi(mi: Union[float, GenArrayLike]) -> GenArrayLike:
     """
 
     # If the parameter is a pandas type, preserve the columns and indices
-    # In pandas 2.1 applymap was renamed to map,
-    # so use that if possible, and fall back to older function if that fails
-    # (since our support goes all the way to pandas 1.0).
     if "pandas" in sys.modules:
         import pandas
         if isinstance(mi, (pandas.DataFrame, pandas.Series)):
-            if "map" in pandas.DataFrame.__dict__:
-                return mi.map(_normalize)
-            else:
-                return mi.applymap(_normalize)
+            return mi.map(_normalize)
     
     return np.vectorize(_normalize, otypes=[float])(mi)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(description_file, encoding="utf-8") as f:
 
 setup(
     name = "ennemi",
-    version = "1.4.0",
+    version = "1.5.0",
     description = "Non-linear correlation detection with mutual information",
     long_description = long_description,
     long_description_content_type = "text/markdown",
@@ -25,9 +25,9 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Scientific/Engineering :: Mathematics",
@@ -45,9 +45,9 @@ setup(
 
     packages = [ "ennemi" ],
     package_data = { "ennemi": ["py.typed"] },
-    python_requires = "~=3.10",
-    install_requires = [ "numpy>=1.23", "scipy~=1.9" ],
+    python_requires = "~=3.11",
+    install_requires = [ "numpy>=1.24", "scipy~=1.10" ],
     extras_require = {
-        "dev": [ "pandas>=1.5", "pytest~=8.0", "mypy~=1.9" ]
+        "dev": [ "pandas>=2.0", "pytest~=8.0", "mypy~=1.9" ]
     }
 )

--- a/tests/integration/test_lorenz.py
+++ b/tests/integration/test_lorenz.py
@@ -75,7 +75,7 @@ class TestLorenz(unittest.TestCase):
         argmax = np.argmax(mi)
         self.assertEqual(lags[argmax], 10)
         self.assertAlmostEqual(mi[argmax], 0.5, delta=0.05)
-        self.assertGreaterEqual(np.sum(mi > 0.2), 4)
+        self.assertGreaterEqual(np.sum(mi > 0.2), 4) # type: ignore
 
         # I(Y1; Y3) should have a peak at roughly lag=27
         mi = estimate_mi(data[:,0], data[:,2], lags).flatten()

--- a/tests/unit/test_driver.py
+++ b/tests/unit/test_driver.py
@@ -1501,9 +1501,9 @@ class TestPairwiseMi(unittest.TestCase):
         data[:50,0] = np.nan
         data[950:,1] = np.nan
 
-        cond = rng.uniform(size=data.shape)
-        cond[100:120,0] = np.nan
-        cond[900:960,0] = np.nan
+        cond = rng.uniform(size=data.shape) # mypy does not realize that cond is an array
+        cond[100:120,0] = np.nan # type: ignore
+        cond[900:960,0] = np.nan # type: ignore
 
         mi = pairwise_mi(data, cond=cond, normalize=True, drop_nan=True)
         self.assertAlmostEqual(mi[0,1], 0.8, delta=0.02)

--- a/tests/unit/test_entropy_estimators.py
+++ b/tests/unit/test_entropy_estimators.py
@@ -388,7 +388,8 @@ class TestEstimateConditionalSemiDiscreteMi(unittest.TestCase):
         y[x > 2.0] = 4
 
         uncond = _estimate_semidiscrete_mi(w, y, k=1)
-        cond = _estimate_conditional_semidiscrete_mi(w, y, z, k=1)
+        # mypy does not understand that z is an array, not float (coming from rng.normal)
+        cond = _estimate_conditional_semidiscrete_mi(w, y, z, k=1) # type: ignore
 
         # The expected MI is the discrete entropy of Y
         p_low = gamma_dist.cdf(0.5, a=1.5)


### PR DESCRIPTION
- Drop the workaround and testing for pandas 1.x. Closes #121.
- Add Python 3.13 to CI. Since only the macOS runners have cached 3.13 at the moment, run it there. (I know that the script would download and install uncached 3.13 just fine, but I'm not patient enough for that...)
- Add a couple of `#type: ignore` comments to make `mypy` happy: it does not understand that the return type from random number generation is `ndarray` and not `float`. Part of #48.

Filed #123 for adding Python 3.13 experimental features to the test suite later.