### PR TITLE
Migrate to 'build' package

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -60,12 +60,6 @@ jobs:
         run: |
           python -m pytest tests/unit/ --junit-xml=test-results.xml
 
-      - name: Try building the package
-        if: matrix.analysis == true
-        run: |
-          pip install setuptools wheel
-          python setup.py sdist bdist_wheel
-
       - name: Run type checker
         run: |
           python -m mypy ennemi/ tests/unit tests/integration tests/pandas

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -19,11 +19,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install setuptools wheel
+          pip install build
 
       - name: Build package
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
 
       - name: Push to PyPI
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/try-package-build.yml
+++ b/.github/workflows/try-package-build.yml
@@ -1,0 +1,57 @@
+name: Try building the package
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install build
+
+      - name: Build package
+        run: |
+          python -m build
+
+      - name: Store the package
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          compression-level: 0
+          if-no-files-found: error
+  
+  publish-test-pypi:
+    name: Upload built package to Test PyPI (only for testing)
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/p/ennemi/
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download the package
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -15,9 +15,9 @@ with no theoretical background required.
   - Algorithms verified to work, so that you can focus on your data
 
 This package depends only on NumPy and SciPy;
-Pandas is suggested for more enjoyable data analysis.
+Pandas (2.x or newer) is suggested for more enjoyable data analysis.
 Recent versions of NumPy 1.x and 2.x are supported.
-Python 3.10+ on the latest macOS, Ubuntu and Windows versions
+Python 3.11+ on the latest macOS, Ubuntu and Windows versions
 is officially supported.
 Older `ennemi` versions have generally identical behavior if you need to run on older Python.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# PyPI description stored separately from README
+include DESCRIPTION.md

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can also follow the development by clicking `Watch releases` on the GitHub p
 
 ## Getting started
 
-This package requires Python 3.8 or higher,
+This package requires Python 3.11 or higher,
 and it is tested to work on the latest versions of Ubuntu, macOS and Windows.
 The only hard dependencies are reasonably recent versions of NumPy and SciPy;
 Pandas is strongly suggested for more enjoyable data analysis.
@@ -63,6 +63,12 @@ To run the check yourself, execute
 python -m mypy ennemi/ tests/unit tests/integration tests/pandas
 ```
 in the repository root (configuration is stored in `mypy.ini` file).
+
+Distribution packages (source package and wheel) are created with the `build` package:
+```sh
+pip install build
+python -m build
+```
 
 Please see also the [contribution guidelines](CONTRIBUTING.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     python_requires = "~=3.11",
     install_requires = [ "numpy>=1.24", "scipy~=1.10" ],
     extras_require = {
-        "dev": [ "pandas>=2.0", "pytest~=8.0", "mypy~=1.9" ]
+        "dev": [ "build~=1.2", "pandas>=2.0", "pytest~=8.0", "mypy~=1.9" ]
     }
 )


### PR DESCRIPTION
- Migrate away from directly calling `setup.py` (https://packaging.python.org/en/latest/discussions/setup-py-deprecated)
- Add a temporary Test PyPI publish workflow as part of #122
  - Move the "try building package" step to this workflow