### PR TITLE
Finish PyPI publish migration

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,0 +1,49 @@
+name: Code analysis
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install test dependencies
+        run: |
+          pip install -e .[dev]
+      
+      - name: Run unit tests with coverage
+        # We have to rename the path in coverage.xml since Sonar is run in Docker
+        # and has a different view of the file system
+        run: |
+          pip install pytest-cov
+          python -m pytest tests/unit/ --cov=ennemi --cov-report=xml --junit-xml=test-results.xml
+          sed 's/\/home\/runner\/work\/ennemi\/ennemi/\/github\/workspace/g' coverage.xml > coverage-mod.xml
+
+      - name: Run type checker
+        run: |
+          python -m mypy ennemi/ tests/unit tests/integration tests/pandas
+      
+      - name: Run Sonar code analysis
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,20 +17,15 @@ jobs:
         # Save a bit of resources by running only some combinations:
         # Windows 3.11; macOS 3.13; Ubuntu 3.12 (as of this writing, cached 3.13 is on macOS only)
         # macOS is tested both on ARM and x86-64 processors
-        # Code coverage, SonarCloud and test package build are only done once
         include:
           - os: ubuntu-latest
             python-version: '3.12'
-            analysis: true
           - os: windows-latest
             python-version: '3.11'
-            analysis: false
           - os: macos-13
             python-version: '3.13'
-            analysis: false
           - os: macos-15
             python-version: '3.13'
-            analysis: false
 
 
     steps:
@@ -46,27 +41,6 @@ jobs:
         run: |
           pip install -e .[dev]
       
-      - name: Run unit tests (with coverage)
-        if: matrix.analysis == true
-        # We have to rename the path in coverage.xml since Sonar is run in Docker
-        # and has a different view of the file system
+      - name: Run all tests
         run: |
-          pip install pytest-cov
-          python -m pytest tests/unit/ --cov=ennemi --cov-report=xml --junit-xml=test-results.xml
-          sed 's/\/home\/runner\/work\/ennemi\/ennemi/\/github\/workspace/g' coverage.xml > coverage-mod.xml
-      
-      - name: Run unit tests (no coverage)
-        if: matrix.analysis != true
-        run: |
-          python -m pytest tests/unit/ --junit-xml=test-results.xml
-
-      - name: Run type checker
-        run: |
-          python -m mypy ennemi/ tests/unit tests/integration tests/pandas
-      
-      - name: Run Sonar code analysis
-        if: matrix.analysis == true
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          python -m pytest . --junit-xml=test-results.xml

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -25,8 +25,31 @@ jobs:
         run: |
           python -m build
 
-      - name: Push to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+      - name: Store the package
+        uses: actions/upload-artifact@v4
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          name: python-package-distributions
+          path: dist/
+          compression-level: 0
+          if-no-files-found: error
+  
+  publish-pypi:
+    name: Upload built package to PyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ennemi/
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download the package
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/try-package-build.yml
+++ b/.github/workflows/try-package-build.yml
@@ -26,6 +26,7 @@ jobs:
           python -m build
 
       - name: Store the package
+        if: false
         uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
@@ -34,7 +35,8 @@ jobs:
           if-no-files-found: error
   
   publish-test-pypi:
-    name: Upload built package to Test PyPI (only for testing)
+    name: Upload built package to Test PyPI (disabled, only for testing)
+    if: false
     needs:
       - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Migrate the real PyPI script to same configuration as Test PyPI
- Disable the Test PyPI script
- Move code analysis from CI script to a separate workflow
  - This should make the `master` branch visible on SonarCloud again since this workflow is run on pushes as well